### PR TITLE
Implement DiffProvider for batch operations and fix getCurrentRevision

### DIFF
--- a/plugin.idea/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSDiffProvider.java
+++ b/plugin.idea/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSDiffProvider.java
@@ -24,13 +24,16 @@ import com.intellij.openapi.vcs.AbstractVcsHelper;
 import com.intellij.openapi.vcs.FilePath;
 import com.intellij.openapi.vcs.VcsException;
 import com.intellij.openapi.vcs.changes.ContentRevision;
-import com.intellij.openapi.vcs.diff.DiffProvider;
+import com.intellij.openapi.vcs.diff.DiffProviderEx;
 import com.intellij.openapi.vcs.diff.ItemLatestState;
 import com.intellij.openapi.vcs.history.VcsRevisionNumber;
+import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.containers.ContainerUtil;
 import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.context.rest.VersionControlRecursionTypeCaseSensitive;
+import com.microsoft.alm.plugin.external.models.ItemInfo;
 import com.microsoft.alm.plugin.external.models.Workspace;
 import com.microsoft.alm.plugin.external.utils.CommandUtils;
 import com.microsoft.alm.plugin.idea.common.services.LocalizationServiceImpl;
@@ -49,8 +52,9 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Map;
 
-public class TFSDiffProvider implements DiffProvider {
+public class TFSDiffProvider extends DiffProviderEx {
     private static final Logger logger = LoggerFactory.getLogger(TFSDiffProvider.class);
     private static final int MINIMAL_WAIT_FOR_RETRY = 60 * 1000;
 
@@ -112,6 +116,36 @@ public class TFSDiffProvider implements DiffProvider {
                     new VcsException(LocalizationServiceImpl.getInstance().getExceptionMessage(e), e), TFSVcs.TFVC_NAME);
         }
         return VcsRevisionNumber.NULL;
+    }
+
+    @Override
+    public Map<VirtualFile, VcsRevisionNumber> getCurrentRevisions(Iterable<VirtualFile> files) {
+        final ServerContext context = TFSVcs.getInstance(project).getServerContext(true);
+        final List<String> filePaths = ContainerUtil.newArrayList();
+        for (VirtualFile file : files) {
+            String filePath = file.getPath();
+            filePaths.add(filePath);
+        }
+
+        final Map<VirtualFile, VcsRevisionNumber> revisionMap = ContainerUtil.newHashMap();
+        final List<ItemInfo> statusList = CommandUtils.getItemInfos(context, null, filePaths);
+        final LocalFileSystem fs = LocalFileSystem.getInstance();
+        for (ItemInfo info : statusList) {
+            final String itemPath = info.getLocalItem();
+            final VirtualFile virtualFile = fs.findFileByPath(itemPath);
+            final TfsRevisionNumber revision = new TfsRevisionNumber(
+                    info.getLocalVersionAsInt(),
+                    itemPath,
+                    null);
+            if (virtualFile == null) {
+                logger.error("VirtualFile not found for item " + itemPath);
+                continue;
+            }
+
+            revisionMap.put(virtualFile, revision);
+        }
+
+        return revisionMap;
     }
 
     public ItemLatestState getLastRevision(final FilePath localPath) {


### PR DESCRIPTION
### Speed improvement

The main impact of this PR is that it improves the performance of `getCurrentRevisions` by extending the `DiffProviderEx` class that has a specialization for batch operation. _(This operation gets called when the user hits a "Refresh" button in VCS log tool window.)_

Now, instead of multiple HTTP requests to retrieve the local revisions of items involved, the `TFSDiffProvider` will perform a single batch `tf` operation.

On my test repository where I have a big commit with 1500 files, old `TFSDiffProvider` implementation couldn't update the history in 10 minutes and failed with `OutOfMemoryError` afterwards. The new implementation performs the operation in about 5 minutes and doesn't increase the memory footprint in a noticeable way.

Unfortunately, `tf info` still has to go to server to retrieve additional information we don't use. If the command line TFS client would support operation such as `localversions`, then the performance may be significantly improved once again. I've filed [a feature request](https://github.com/Microsoft/team-explorer-everywhere/issues/299) about that command, please see the details there.

### Correctness improvement

From the `TFSDiffProvider` code it looks that it returns the same value for both `getCurrentRevision` and `getLastRevision` return the same value. This seems to be wrong: `getCurrentRevision` should return a current local version and not the server one. Thus I've changed the `getCurrentRevision` code to use the same mechanism used by the new batch operation `getCurrentRevisions`.