### PR TITLE
Use IDEA certificate manager

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,8 +166,9 @@ subprojects {
         compile group: 'com.microsoft.alm', name: 'alm-http-client-dep', version: '0.4.3-SNAPSHOT'
         compile group: 'commons-io', name: 'commons-io', version: '2.4'
         compile group: 'com.google.guava', name: 'guava', version: '27.1-jre'
-        compile group: 'org.glassfish.jersey.core', name: 'jersey-client', version: '2.6'
-        compile group: 'org.glassfish.jersey.connectors', name: 'jersey-apache-connector', version: '2.6'
+        compile group: 'org.glassfish.jersey.core', name: 'jersey-client', version: '2.28'
+        compile group: 'org.glassfish.jersey.connectors', name: 'jersey-apache-connector', version: '2.28'
+        compile group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '2.28'
         compile (group: 'org.apache.httpcomponents', name: 'httpclient-win', version: '4.4.1') {
             /* Task 454223: exclude default JNA dependency (would be version 4.1.0 as of this writing) */
             exclude group: 'net.java.dev.jna', module: 'jna'

--- a/plugin.idea/src/com/microsoft/alm/plugin/idea/common/services/IdeaCertificateService.java
+++ b/plugin.idea/src/com/microsoft/alm/plugin/idea/common/services/IdeaCertificateService.java
@@ -1,0 +1,13 @@
+package com.microsoft.alm.plugin.idea.common.services;
+
+import com.intellij.util.net.ssl.CertificateManager;
+import com.microsoft.alm.plugin.services.CertificateService;
+
+import javax.net.ssl.SSLContext;
+
+public class IdeaCertificateService implements CertificateService {
+    @Override
+    public SSLContext getSSLContext() {
+        return CertificateManager.getInstance().getSslContext();
+    }
+}

--- a/plugin.idea/src/com/microsoft/alm/plugin/idea/common/setup/ApplicationStartup.java
+++ b/plugin.idea/src/com/microsoft/alm/plugin/idea/common/setup/ApplicationStartup.java
@@ -15,6 +15,7 @@ import com.microsoft.alm.plugin.idea.common.services.CredentialsPromptImpl;
 import com.microsoft.alm.plugin.idea.common.services.DeviceFlowResponsePromptImpl;
 import com.microsoft.alm.plugin.idea.common.services.HttpProxyServiceImpl;
 import com.microsoft.alm.plugin.idea.common.services.IdeaAsyncService;
+import com.microsoft.alm.plugin.idea.common.services.IdeaCertificateService;
 import com.microsoft.alm.plugin.idea.common.services.LocalizationServiceImpl;
 import com.microsoft.alm.plugin.idea.common.services.PropertyServiceImpl;
 import com.microsoft.alm.plugin.idea.common.services.ServerContextStoreImpl;
@@ -63,6 +64,7 @@ public class ApplicationStartup implements ApplicationComponent {
                 LocalizationServiceImpl.getInstance(),
                 new HttpProxyServiceImpl(),
                 new IdeaAsyncService(),
+                new IdeaCertificateService(),
                 true);
 
         final File vstsDirectory = setupPreferenceDir(USER_HOME_DIR);

--- a/plugin.idea/src/com/microsoft/alm/plugin/idea/common/ui/common/ServerContextTableModel.java
+++ b/plugin.idea/src/com/microsoft/alm/plugin/idea/common/ui/common/ServerContextTableModel.java
@@ -4,6 +4,9 @@
 package com.microsoft.alm.plugin.idea.common.ui.common;
 
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
 import com.microsoft.alm.common.utils.UrlHelper;
 import com.microsoft.alm.core.webapi.model.TeamProjectCollectionReference;
 import com.microsoft.alm.core.webapi.model.TeamProjectReference;
@@ -11,10 +14,8 @@ import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.idea.common.resources.TfPluginBundle;
 import com.microsoft.alm.plugin.idea.common.utils.VcsHelper;
 import com.microsoft.alm.sourcecontrol.webapi.model.GitRepository;
-import jersey.repackaged.com.google.common.base.Predicate;
-import jersey.repackaged.com.google.common.collect.Collections2;
-import jersey.repackaged.com.google.common.collect.Lists;
 import org.apache.commons.lang.StringUtils;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import javax.swing.DefaultListSelectionModel;
 import javax.swing.ListSelectionModel;
@@ -303,6 +304,11 @@ public class ServerContextTableModel extends AbstractTableModel {
                 @Override
                 public boolean apply(ServerContext repositoryRow) {
                     return rowContains(repositoryRow);
+                }
+
+                @Override
+                public boolean test(@Nullable ServerContext input) {
+                    return apply(input);
                 }
             }));
         }

--- a/plugin.idea/src/com/microsoft/alm/plugin/idea/common/ui/workitem/WorkItemsTableModel.java
+++ b/plugin.idea/src/com/microsoft/alm/plugin/idea/common/ui/workitem/WorkItemsTableModel.java
@@ -4,14 +4,15 @@
 package com.microsoft.alm.plugin.idea.common.ui.workitem;
 
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
 import com.microsoft.alm.common.utils.SystemHelper;
-import com.microsoft.alm.plugin.idea.common.ui.common.TableModelSelectionConverter;
 import com.microsoft.alm.plugin.idea.common.ui.common.FilteredModel;
+import com.microsoft.alm.plugin.idea.common.ui.common.TableModelSelectionConverter;
 import com.microsoft.alm.workitemtracking.webapi.models.WorkItem;
-import jersey.repackaged.com.google.common.base.Predicate;
-import jersey.repackaged.com.google.common.collect.Collections2;
-import jersey.repackaged.com.google.common.collect.Lists;
 import org.apache.commons.lang.StringUtils;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import javax.swing.DefaultListSelectionModel;
 import javax.swing.ListSelectionModel;
@@ -240,6 +241,11 @@ public class WorkItemsTableModel extends AbstractTableModel implements FilteredM
                 @Override
                 public boolean apply(WorkItem item) {
                     return rowContains(item);
+                }
+
+                @Override
+                public boolean test(@Nullable WorkItem input) {
+                    return apply(input);
                 }
             }));
         }

--- a/plugin.idea/test/com/microsoft/alm/plugin/idea/IdeaAbstractTest.java
+++ b/plugin.idea/test/com/microsoft/alm/plugin/idea/IdeaAbstractTest.java
@@ -7,6 +7,7 @@ import com.microsoft.alm.plugin.AbstractTest;
 import com.microsoft.alm.plugin.idea.common.services.CredentialsPromptImpl;
 import com.microsoft.alm.plugin.idea.common.services.DeviceFlowResponsePromptImpl;
 import com.microsoft.alm.plugin.idea.common.services.HttpProxyServiceImpl;
+import com.microsoft.alm.plugin.idea.common.services.IdeaCertificateService;
 import com.microsoft.alm.plugin.idea.common.services.LocalizationServiceImpl;
 import com.microsoft.alm.plugin.idea.common.services.PropertyServiceImpl;
 import com.microsoft.alm.plugin.idea.common.services.ServerContextStoreImpl;
@@ -34,6 +35,7 @@ public class IdeaAbstractTest extends AbstractTest {
                         runnable.run();
                     }
                 },
+                new IdeaCertificateService(),
                 false);
 
         // ensure the AbstractTest's setup method is called as well.

--- a/plugin/src/com/microsoft/alm/plugin/context/ServerContext.java
+++ b/plugin/src/com/microsoft/alm/plugin/context/ServerContext.java
@@ -14,6 +14,7 @@ import com.microsoft.alm.plugin.context.rest.GitHttpClientEx;
 import com.microsoft.alm.plugin.context.rest.TfvcHttpClientEx;
 import com.microsoft.alm.plugin.context.soap.SoapServices;
 import com.microsoft.alm.plugin.context.soap.SoapServicesImpl;
+import com.microsoft.alm.plugin.services.PluginServiceProvider;
 import com.microsoft.alm.sourcecontrol.webapi.model.GitRepository;
 import com.microsoft.alm.workitemtracking.webapi.WorkItemTrackingHttpClient;
 import org.apache.http.auth.AuthScope;
@@ -23,9 +24,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.glassfish.jersey.SslConfigurator;
 
-import javax.net.ssl.SSLContext;
 import javax.ws.rs.client.Client;
 import java.io.IOException;
 import java.net.URI;
@@ -152,14 +151,8 @@ public class ServerContext {
             final Credentials credentials = AuthHelper.getCredentials(type, authenticationInfo);
             final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
             credentialsProvider.setCredentials(AuthScope.ANY, credentials);
-            final HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
-
-            if (RestClientHelper.isSSLEnabledOnPrem(Type.TFS, authenticationInfo.getServerUri())) {
-                final SslConfigurator sslConfigurator = RestClientHelper.getSslConfigurator();
-                final SSLContext sslContext = sslConfigurator.createSSLContext();
-
-                httpClientBuilder.setSslcontext(sslContext);
-            }
+            final HttpClientBuilder httpClientBuilder = HttpClientBuilder.create()
+                    .setSSLContext(PluginServiceProvider.getInstance().getCertificateService().getSSLContext());
 
             httpClient = httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider).build();
         }

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
@@ -4,6 +4,7 @@
 package com.microsoft.alm.plugin.external.commands;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.SettableFuture;
 import com.microsoft.alm.common.utils.ArgumentHelper;
 import com.microsoft.alm.helpers.Path;
 import com.microsoft.alm.plugin.context.ServerContext;
@@ -15,7 +16,6 @@ import com.microsoft.alm.plugin.external.exceptions.ToolParseFailureException;
 import com.microsoft.alm.plugin.external.models.Workspace;
 import com.microsoft.alm.plugin.external.tools.TfTool;
 import com.microsoft.alm.plugin.external.utils.WorkspaceHelper;
-import jersey.repackaged.com.google.common.util.concurrent.SettableFuture;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/StatusCommand.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/StatusCommand.java
@@ -3,10 +3,10 @@
 
 package com.microsoft.alm.plugin.external.commands;
 
+import com.google.common.collect.ImmutableList;
 import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.external.ToolRunner;
 import com.microsoft.alm.plugin.external.models.PendingChange;
-import jersey.repackaged.com.google.common.collect.ImmutableList;
 import org.apache.commons.lang.StringUtils;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;

--- a/plugin/src/com/microsoft/alm/plugin/external/models/Workspace.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/models/Workspace.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.alm.plugin.external.models;
 
-import jersey.repackaged.com.google.common.base.Objects;
+import com.google.common.base.Objects;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;

--- a/plugin/src/com/microsoft/alm/plugin/services/CertificateService.java
+++ b/plugin/src/com/microsoft/alm/plugin/services/CertificateService.java
@@ -1,0 +1,10 @@
+package com.microsoft.alm.plugin.services;
+
+import javax.net.ssl.SSLContext;
+
+/**
+ * Service that provides system SSL certificate store access.
+ */
+public interface CertificateService {
+    SSLContext getSSLContext();
+}

--- a/plugin/src/com/microsoft/alm/plugin/services/PluginServiceProvider.java
+++ b/plugin/src/com/microsoft/alm/plugin/services/PluginServiceProvider.java
@@ -3,6 +3,8 @@
 
 package com.microsoft.alm.plugin.services;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * This class is a singleton that holds all of the services that must be provided by the plugin that uses this module.
  * When the plugin is loaded for the first time, this class must be initialized. It may only be initialized once.
@@ -20,6 +22,7 @@ public class PluginServiceProvider {
     private LocalizationService localizationSerivce;
     private HttpProxyService httpProxyService;
     private AsyncService asyncService;
+    private CertificateService certificateService;
 
     private static class ProviderHolder {
         private static PluginServiceProvider INSTANCE = new PluginServiceProvider();
@@ -36,6 +39,7 @@ public class PluginServiceProvider {
                            final LocalizationService localizationService,
                            final HttpProxyService httpProxyService,
                            final AsyncService asyncService,
+                           final CertificateService certificateService,
                            final boolean insideIDE) {
         if (!initialized) {
             this.contextStore = contextStore;
@@ -45,6 +49,7 @@ public class PluginServiceProvider {
             this.localizationSerivce = localizationService;
             this.httpProxyService = httpProxyService;
             this.asyncService = asyncService;
+            this.certificateService = certificateService;
             this.insideIDE = insideIDE;
             initialized = true;
         }
@@ -105,5 +110,13 @@ public class PluginServiceProvider {
         assert asyncService != null;
 
         return asyncService;
+    }
+
+    @NotNull
+    public CertificateService getCertificateService() {
+        assert initialized;
+        assert certificateService != null;
+
+        return certificateService;
     }
 }

--- a/plugin/test/com/microsoft/alm/plugin/AbstractTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/AbstractTest.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.alm.plugin;
 
+import com.microsoft.alm.plugin.mocks.MockCertificateService;
 import com.microsoft.alm.plugin.mocks.MockCredentialsPrompt;
 import com.microsoft.alm.plugin.mocks.MockHttpProxyService;
 import com.microsoft.alm.plugin.mocks.MockLocalizationService;
@@ -32,7 +33,7 @@ public class AbstractTest {
                     public void executeOnPooledThread(Runnable runnable) {
                         runnable.run();
                     }
-                }, false);
+                }, new MockCertificateService(), false);
     }
 
     public static void assertLogged(final String s) {

--- a/plugin/test/com/microsoft/alm/plugin/authentication/TfsAuthenticationProviderTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/authentication/TfsAuthenticationProviderTest.java
@@ -3,13 +3,13 @@
 
 package com.microsoft.alm.plugin.authentication;
 
+import com.google.common.util.concurrent.SettableFuture;
 import com.microsoft.alm.plugin.AbstractTest;
 import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.context.ServerContextBuilder;
 import com.microsoft.alm.plugin.context.ServerContextManager;
 import com.microsoft.alm.plugin.mocks.MockCredentialsPrompt;
 import com.microsoft.alm.plugin.services.PluginServiceProvider;
-import jersey.repackaged.com.google.common.util.concurrent.SettableFuture;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/plugin/test/com/microsoft/alm/plugin/context/ServerContextTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/context/ServerContextTest.java
@@ -3,12 +3,12 @@
 
 package com.microsoft.alm.plugin.context;
 
+import com.microsoft.alm.core.webapi.model.TeamProjectCollectionReference;
+import com.microsoft.alm.core.webapi.model.TeamProjectReference;
 import com.microsoft.alm.plugin.AbstractTest;
 import com.microsoft.alm.plugin.authentication.AuthenticationInfo;
 import com.microsoft.alm.plugin.context.soap.SoapServices;
 import com.microsoft.alm.plugin.context.soap.SoapServicesImpl;
-import com.microsoft.alm.core.webapi.model.TeamProjectCollectionReference;
-import com.microsoft.alm.core.webapi.model.TeamProjectReference;
 import com.microsoft.alm.sourcecontrol.webapi.model.GitRepository;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
@@ -21,6 +21,7 @@ import org.glassfish.jersey.client.RequestEntityProcessing;
 import org.junit.Assert;
 import org.junit.Test;
 
+import javax.ws.rs.client.Client;
 import java.net.URI;
 import java.util.Map;
 
@@ -111,14 +112,17 @@ public class ServerContextTest extends AbstractTest {
         //proxy setting doesn't automatically mean we need to setup ssl trust store anymore
         Assert.assertEquals(4, properties2.size());
         Assert.assertNotNull(properties2.get(ClientProperties.PROXY_URI));
-        Assert.assertNull(properties2.get(ApacheClientProperties.SSL_CONFIG));
 
         info = new AuthenticationInfo("users1", "pass", "https://tfsonprem.test", "4display");
         final ClientConfig config3 = RestClientHelper.getClientConfig(ServerContext.Type.TFS, info, false);
         final Map<String, Object> properties3 = config3.getProperties();
-        Assert.assertEquals(4, properties3.size());
+        Assert.assertEquals(3, properties3.size());
         Assert.assertNull(properties3.get(ClientProperties.PROXY_URI));
-        Assert.assertNotNull(properties3.get(ApacheClientProperties.SSL_CONFIG));
     }
 
+    @Test
+    public void getClientSslContext() {
+        Client client = RestClientHelper.getClient("https://tfsonprem.test", "testToken");
+        Assert.assertNotNull(client.getSslContext());
+    }
 }

--- a/plugin/test/com/microsoft/alm/plugin/events/ServerPollingManagerTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/events/ServerPollingManagerTest.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.alm.plugin.events;
 
-import jersey.repackaged.com.google.common.util.concurrent.SettableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/plugin/test/com/microsoft/alm/plugin/mocks/MockCertificateService.java
+++ b/plugin/test/com/microsoft/alm/plugin/mocks/MockCertificateService.java
@@ -1,0 +1,17 @@
+package com.microsoft.alm.plugin.mocks;
+
+import com.microsoft.alm.plugin.services.CertificateService;
+
+import javax.net.ssl.SSLContext;
+import java.security.NoSuchAlgorithmException;
+
+public class MockCertificateService implements CertificateService {
+    @Override
+    public SSLContext getSSLContext() {
+        try {
+            return SSLContext.getDefault();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/plugin/test/com/microsoft/alm/plugin/operations/ServerContextLookupOperationTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/operations/ServerContextLookupOperationTest.java
@@ -4,14 +4,14 @@
 package com.microsoft.alm.plugin.operations;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.SettableFuture;
+import com.microsoft.alm.core.webapi.model.TeamProjectCollectionReference;
+import com.microsoft.alm.core.webapi.model.TeamProjectReference;
 import com.microsoft.alm.plugin.authentication.AuthenticationInfo;
 import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.context.ServerContextBuilder;
 import com.microsoft.alm.plugin.mocks.MockServerContextLookupOperation;
-import com.microsoft.alm.core.webapi.model.TeamProjectCollectionReference;
-import com.microsoft.alm.core.webapi.model.TeamProjectReference;
 import com.microsoft.alm.sourcecontrol.webapi.model.GitRepository;
-import jersey.repackaged.com.google.common.util.concurrent.SettableFuture;
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
Now users will be able to select the trusted certificates using the [standard IDEA mechanism](https://www.jetbrains.com/help/idea/settings-tools-server-certificates.html):
![image](https://user-images.githubusercontent.com/92793/55869300-7366cf00-5bb0-11e9-8ee3-d9681a5d7434.png)

To implement the feature, I had to update jersey libraries to a recent version (because jersey-apache-connector 2.6 contains a bug which prevents SSLContext from being passed inside of jersey sometimes).

- Closes #105.