### PR TITLE
Make getLastCommitHash faster

### DIFF
--- a/plugin.idea/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
+++ b/plugin.idea/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
@@ -53,9 +53,6 @@ ToolException.TF.BranchExists=The branch ''{0}'' already exists on the server. P
 ToolException.TF.OOM=The TF command line tool does not have enough memory to run. Please decrease the memory of the tool by:\n1) Open the executable: {0}\n2) Decrease the memory set by the -Xmx argument
 ToolException.TF.Auth.Fail=The TF command line failed to authenticate to the server. Please make sure you have access to the server and/or have entered the correct credentials.
 
-#Common Git
-Git.History.Errors.NoHistoryFound=No Git history was found for {0} branch.
-
 #Checkout dialog ui and models
 CheckoutDialog.TfsTab=Team Foundation Server
 CheckoutDialog.VsoTab=Azure DevOps Services

--- a/plugin.idea/src/com/microsoft/alm/plugin/idea/common/resources/TfPluginBundle.java
+++ b/plugin.idea/src/com/microsoft/alm/plugin/idea/common/resources/TfPluginBundle.java
@@ -106,10 +106,6 @@ public class TfPluginBundle {
     @NonNls
     public static final String KEY_VSO_NO_PROFILE_ERROR_HELP = "VSO.NoProfileError.Help";
 
-    // Common Git
-    @NonNls
-    public static final String KEY_GIT_HISTORY_ERRORS_NO_HISTORY_FOUND = "Git.History.Errors.NoHistoryFound";
-
     // Common TFVC
     @NonNls
     public static final String KEY_ERRORS_UNABLE_TO_DETERMINE_WORKSPACE = "Errors.UnableToDetermineWorkspace";

--- a/plugin.idea/src/com/microsoft/alm/plugin/idea/git/utils/GeneralGitHelper.java
+++ b/plugin.idea/src/com/microsoft/alm/plugin/idea/git/utils/GeneralGitHelper.java
@@ -5,14 +5,10 @@ package com.microsoft.alm.plugin.idea.git.utils;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vcs.VcsException;
-import com.microsoft.alm.plugin.idea.common.resources.TfPluginBundle;
 import git4idea.GitBranch;
-import git4idea.GitCommit;
-import git4idea.history.GitHistoryUtils;
+import git4idea.GitRevisionNumber;
 import git4idea.repo.GitRepository;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
 
 /**
  * General helper class for Git functionality using Git4idea
@@ -30,22 +26,11 @@ public class GeneralGitHelper {
      */
     public static String getLastCommitHash(@NotNull final Project project, @NotNull final GitRepository gitRepository,
                                            @NotNull final GitBranch branch) throws VcsException {
-        final List<GitCommit> branchHistory;
-
         try {
-            branchHistory = GitHistoryUtils.history(project, gitRepository.getRoot(), branch.getName());
+            GitRevisionNumber revision = GitRevisionNumber.resolve(project, gitRepository.getRoot(), branch.getName());
+            return revision.asString();
         } catch (VcsException e) {
             throw new VcsException(e.getCause());
         }
-
-        // check that history exists in branch. If not, throw an exception because there is no acceptable scenario
-        // where a branch will have no history. We need the hash to do the diff.
-        if (branchHistory.isEmpty()) {
-            throw new VcsException(TfPluginBundle.message(TfPluginBundle.KEY_GIT_HISTORY_ERRORS_NO_HISTORY_FOUND,
-                    branch.getName()));
-        }
-
-        // get hash of last commit
-        return branchHistory.get(0).getId().asString();
     }
 }


### PR DESCRIPTION
Closes #181.

While investigating #181, I've found that most of the time is wasted inside of the `GitHistoryUtils::history` call that's called from `GeneralGitHelper::getLastCommitHash`. It was parsing the whole Git history of branches in question to determine the last commit hash.

There's a faster API to determine the hash of the last commit, so, by using that, we could make the whole process much faster. On my repos, #181 no more reproduces in any kind: everything works fast now.