### PR TITLE
Fix authentication issues

### DIFF
--- a/common/src/com/microsoft/alm/common/utils/UrlHelper.java
+++ b/common/src/com/microsoft/alm/common/utils/UrlHelper.java
@@ -114,6 +114,23 @@ public class UrlHelper {
     }
 
     /**
+     * Removes any user information from an URL, e.g. will remove the "username@" part from the URL
+     * "https://username@dev.azure.com/".
+     */
+    public static String removeUserInfo(final String url) {
+        if (url == null) {
+            return null;
+        }
+
+        try {
+            return new URIBuilder(url).setUserInfo(null).build().toString();
+        } catch (URISyntaxException e) {
+            logger.warn("Invalid URL passed to removeUserInfo: {}", url);
+            return url;
+        }
+    }
+
+    /**
      * Sometimes the Git infrastructure may pass an URL like https://username@dev.azure.com/ (note the username
      * placement). Such URL should be converted into https://dev.azure.com/username to properly serve as a base URL for
      * HTTP API calls.

--- a/common/src/com/microsoft/alm/common/utils/UrlHelper.java
+++ b/common/src/com/microsoft/alm/common/utils/UrlHelper.java
@@ -4,13 +4,16 @@
 package com.microsoft.alm.common.utils;
 
 import com.microsoft.alm.common.artifact.GitRefArtifactID;
+import com.microsoft.alm.helpers.UriHelper;
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -108,6 +111,30 @@ public class UrlHelper {
         }
 
         return uri;
+    }
+
+    /**
+     * Sometimes the Git infrastructure may pass an URL like https://username@dev.azure.com/ (note the username
+     * placement). Such URL should be converted into https://dev.azure.com/username to properly serve as a base URL for
+     * HTTP API calls.
+     * <p />
+     * This method will only process URLs pointing to the azure.com and *.azure.com hosts.
+     */
+    public static String convertToCanonicalHttpApiBase(String url) {
+        if (url == null) {
+            return null;
+        }
+
+        URI uri = URI.create(url);
+        if (UriHelper.isAzureHost(uri)) {
+            String fullAccount = UriHelper.getFullAccount(uri); // dev.azure.com/username
+            String result = uri.getScheme() + "://" + fullAccount; // https://dev.azure.com/username
+            logger.info("Converted an URL {} into canonical HTTP API base: {}", url, result);
+            return result;
+        }
+
+        logger.info("Not an Azure host {}, HTTP API base conversion skipped", url);
+        return url;
     }
 
     public static boolean isVSO(final URI uri) {

--- a/common/test/com/microsoft/alm/common/utils/UrlHelperTest.java
+++ b/common/test/com/microsoft/alm/common/utils/UrlHelperTest.java
@@ -23,13 +23,11 @@ public class UrlHelperTest {
     };
 
     @Test
-    public void testIsValidServerUrl() throws Exception {
-
-    }
-
-    @Test
-    public void testGetBaseUri() throws Exception {
-
+    public void testRemoveUserInfo() {
+        assertEquals("https://dev.azure.com", UrlHelper.removeUserInfo("https://username@dev.azure.com"));
+        assertEquals("https://microsoft.com", UrlHelper.removeUserInfo("https://username@microsoft.com"));
+        assertEquals("https://dev.azure.com", UrlHelper.removeUserInfo("https://dev.azure.com"));
+        assertEquals("https://dev.azure.com", UrlHelper.removeUserInfo("https://username:password@dev.azure.com"));
     }
 
     @Test

--- a/common/test/com/microsoft/alm/common/utils/UrlHelperTest.java
+++ b/common/test/com/microsoft/alm/common/utils/UrlHelperTest.java
@@ -33,6 +33,13 @@ public class UrlHelperTest {
     }
 
     @Test
+    public void testConvertToCanonicalHttpApiBase() {
+        assertEquals("https://dev.azure.com/username", UrlHelper.convertToCanonicalHttpApiBase("https://username@dev.azure.com"));
+        assertEquals("https://username@microsoft.com", UrlHelper.convertToCanonicalHttpApiBase(("https://username@microsoft.com")));
+        assertEquals("http://dev.azure.com", UrlHelper.convertToCanonicalHttpApiBase(("http://dev.azure.com")));
+    }
+
+    @Test
     public void testResolveEndpointURI() throws Exception {
 
         URI expected, resolved;

--- a/plugin.idea/src/com/microsoft/alm/plugin/idea/git/extensions/TfGitHttpAuthDataProvider.java
+++ b/plugin.idea/src/com/microsoft/alm/plugin/idea/git/extensions/TfGitHttpAuthDataProvider.java
@@ -10,6 +10,7 @@ import com.microsoft.alm.plugin.authentication.AuthenticationInfo;
 import com.microsoft.alm.plugin.authentication.VsoAuthenticationProvider;
 import com.microsoft.alm.plugin.context.ServerContextManager;
 import git4idea.remote.GitHttpAuthDataProvider;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,8 +18,8 @@ public class TfGitHttpAuthDataProvider implements GitHttpAuthDataProvider {
     private static final Logger logger = LoggerFactory.getLogger(TfGitHttpAuthDataProvider.class);
 
     @Override
-    public AuthData getAuthData(final String url) {
-        assert url != null;
+    public AuthData getAuthData(@NotNull String url) {
+        url = UrlHelper.convertToCanonicalHttpApiBase(url);
 
         //try to find authentication info from saved server contexts
         final AuthenticationInfo authenticationInfo = ServerContextManager.getInstance().getBestAuthenticationInfo(url, false);
@@ -54,9 +55,10 @@ public class TfGitHttpAuthDataProvider implements GitHttpAuthDataProvider {
     }
 
     @Override
-    public void forgetPassword(final String url) {
+    public void forgetPassword(@NotNull String url) {
         // This method got called since stored credentials for the url resulted in an unauthorized error 401 or 403
-        assert url != null;
+        url = UrlHelper.convertToCanonicalHttpApiBase(url);
+
         if (UrlHelper.isTeamServicesUrl(url)) {
             // IntelliJ calls us with a http server url e.g. http://myorganization.visualstudio.com
             // convert to https:// for team services to avoid rest call failures

--- a/plugin.idea/test/com/microsoft/alm/plugin/idea/git/extensions/TfGitHttpAuthDataProviderTest.java
+++ b/plugin.idea/test/com/microsoft/alm/plugin/idea/git/extensions/TfGitHttpAuthDataProviderTest.java
@@ -1,5 +1,6 @@
 package com.microsoft.alm.plugin.idea.git.extensions;
 
+import com.intellij.openapi.project.Project;
 import com.intellij.util.AuthData;
 import com.microsoft.alm.plugin.authentication.AuthenticationInfo;
 import com.microsoft.alm.plugin.context.ServerContext;
@@ -16,6 +17,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
@@ -56,5 +60,17 @@ public class TfGitHttpAuthDataProviderTest extends IdeaAbstractTest {
         assertNotNull(authData);
         assertEquals(authenticationInfo.getUserName(), authData.getLogin());
         assertEquals(authenticationInfo.getPassword(), authData.getPassword());
+    }
+
+    @Test
+    public void usernameShouldBeCombinedWithAnUrl() {
+        TfGitHttpAuthDataProvider mockedAuthDataProvider = Mockito.mock(TfGitHttpAuthDataProvider.class);
+        when(mockedAuthDataProvider.getAuthData(any(Project.class), any(String.class), any(String.class))).thenCallRealMethod();
+
+        Project project = Mockito.mock(Project.class);
+
+        mockedAuthDataProvider.getAuthData(project, "https://dev.azure.com", "username");
+
+        verify(mockedAuthDataProvider, times(1)).getAuthData("https://username@dev.azure.com");
     }
 }

--- a/plugin.idea/test/com/microsoft/alm/plugin/idea/git/extensions/TfGitHttpAuthDataProviderTest.java
+++ b/plugin.idea/test/com/microsoft/alm/plugin/idea/git/extensions/TfGitHttpAuthDataProviderTest.java
@@ -1,0 +1,60 @@
+package com.microsoft.alm.plugin.idea.git.extensions;
+
+import com.intellij.util.AuthData;
+import com.microsoft.alm.plugin.authentication.AuthenticationInfo;
+import com.microsoft.alm.plugin.context.ServerContext;
+import com.microsoft.alm.plugin.context.ServerContextManager;
+import com.microsoft.alm.plugin.idea.IdeaAbstractTest;
+import com.microsoft.alm.plugin.idea.common.settings.TeamServicesSecrets;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({TeamServicesSecrets.class})
+public class TfGitHttpAuthDataProviderTest extends IdeaAbstractTest {
+    private final AuthenticationInfo authenticationInfo = new AuthenticationInfo(
+            "userName",
+            "password",
+            "serverUri",
+            "userNameForDisplay");
+
+    private TfGitHttpAuthDataProvider authDataProvider;
+
+    @Before
+    public void setUp() {
+        PowerMockito.mockStatic(TeamServicesSecrets.class);
+
+        authDataProvider = new TfGitHttpAuthDataProvider();
+        ServerContext context = Mockito.mock(ServerContext.class);
+        when(context.getKey()).thenReturn(ServerContext.getKey("https://dev.azure.com/username"));
+        when(context.getAuthenticationInfo()).thenReturn(authenticationInfo);
+        ServerContextManager.getInstance().add(context);
+    }
+
+    @Test
+    public void httpAuthShouldWorkOnUrlThatDoesNotRequireConversion() {
+        AuthData authData = authDataProvider.getAuthData("https://dev.azure.com/username");
+
+        assertNotNull(authData);
+        assertEquals(authenticationInfo.getUserName(), authData.getLogin());
+        assertEquals(authenticationInfo.getPassword(), authData.getPassword());
+    }
+
+    @Test
+    public void httpAuthShouldConvertUrlProperly() {
+        AuthData authData = authDataProvider.getAuthData("https://username@dev.azure.com/");
+
+        assertNotNull(authData);
+        assertEquals(authenticationInfo.getUserName(), authData.getLogin());
+        assertEquals(authenticationInfo.getPassword(), authData.getPassword());
+    }
+}

--- a/plugin/src/com/microsoft/alm/plugin/context/ServerContextManager.java
+++ b/plugin/src/com/microsoft/alm/plugin/context/ServerContextManager.java
@@ -702,7 +702,10 @@ public class ServerContextManager {
                 if (UrlHelper.isSshGitRemoteUrl(gitRemoteUrl)) {
                     gitUrlToParse = UrlHelper.getHttpsGitUrlFromSshUrl(gitRemoteUrl);
                 } else {
-                    gitUrlToParse = gitRemoteUrl;
+                    // Trim user info from the URI (e.g. https://username@dev.azure.com → https://dev.azure.com, because
+                    // otherwise the HTTP client will try to use authentication data from the URL instead of the data
+                    // baked into the client itself).
+                    gitUrlToParse = UrlHelper.removeUserInfo(gitRemoteUrl);
                 }
 
                 //query the server endpoint for VSTS repo, project and collection info

--- a/plugin/src/com/microsoft/alm/plugin/context/ServerContextManager.java
+++ b/plugin/src/com/microsoft/alm/plugin/context/ServerContextManager.java
@@ -221,6 +221,11 @@ public class ServerContextManager {
             }
         }
 
+        logger.info(
+                "Validating a {} server context with a server URI {}",
+                context.getType(),
+                contextToValidate == null ? "" : contextToValidate.getServerUri());
+
         if (context.getType() == ServerContext.Type.TFS) {
             return checkTfsVersionAndConnection(contextToValidate);
         } else {
@@ -737,9 +742,6 @@ public class ServerContextManager {
                 }
 
                 serverUrl = vstsInfo.getServerUrl();
-                if (UrlHelper.isOrganizationUrl(serverUrl)) {
-                    serverUrl = serverUrl + "/" + UrlHelper.getAccountFromOrganization(vstsInfo.getRepository().getRemoteUrl());
-                }
 
                 collection = new TeamProjectCollection();
                 collection.setId(vstsInfo.getCollectionReference().getId());

--- a/plugin/test/com/microsoft/alm/plugin/context/ServerContextManagerTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/context/ServerContextManagerTest.java
@@ -364,6 +364,7 @@ public class ServerContextManagerTest extends AbstractTest {
         when(VstsHttpClient.sendRequest(client, repositoryInfoApiUrl, VstsInfo.class)).thenReturn(vstsInfo);
 
         Assert.assertTrue(validator.validateGitUrl(repositoryUrl));
+        Assert.assertEquals("https://dev.azure.com/username", validator.getServerUrl());
     }
 
     @Test


### PR DESCRIPTION
Closes #158.

While investigating #158, I've encountered the following four authentication issues:

1. Git in some cases will ask IDEA to provide the authentication information (see more about that in my last comment in #158). The IDEA Git infrastructure will pass the request to `TfGitHttpAuthDataProvider`: in IDEA 2018.1 and earlier, it will receive an URL like `getAuthData("https://username@dev.azure.com")`.

   This breaks the HTTP API request that will be sent to the server based on the URL (in this case, the API request will be sent to `https://username@dev.azure.com/vsts/info` or something like that, which is invalid), because our infrastructure expects the URL to include a username in an usual place (e.g. `https://dev.azure.com/username`), thus `TfGitHttpAuthDataProvider` has to fix the URL before passing it into the authentication infrastructure (because verifying the URL passed is one of the authentication steps, and that requires HTTP API access).
2. IDEA 2018.2+ has broken the `GitHttpAuthDataProvider` API: a new method overload was introduced that has three arguments (namely, `getAuthData(Project project, String url, String login)`), and old method (that was implemented by us) will now receive the URL without a username. This doesn't work because we need to know the username to solve the previous issue.

   Another problem is that the Azure DevOps plugin is currently compatible with IDEA 2017.1, so it cannot implement an interface method that was added only in 2018.2, and we don't want to drop the support for IDEA 2018.1 and older right now. So I had to use a little trick to implement that interface method (Java will consider an override even without an `@Override` keyword if interface has the same method with the same signature as our class).

   I've thoroughfully documented this hack in the comments to make sure people won't drop this seemingly "unused" method from our `TfGitHttpAuthDataProvider`.
3. Next issue I've encountered was in `ServerContextManager.Validator::validateGitUrl` which is used e.g. when receiving a list of work items. This method may receive a Git remote URL (such as `"https://username@dev.azure.com/username/project/_git/repository"`) and should perform an API request to get the repository info. To perform a request, we use Apache HTTP library and pass a `Client` instance to it. `Client` has HTTP credentials baked into it, but there's a trouble: credentials that are present at the URL itself (e.g. `https://username:password@server`) has priority over the `Client`'s backed credential manager, so it just uses `username` and `password=null` for a request (and that will result in an authentication error even if the credential manager has the right credentials).
4. The last issue discovered was caused by this code in `ServerContextManager`:
   https://github.com/microsoft/azure-devops-intellij/blob/35673c4667b6a2db5f6b73f93a52e643ecc14794/plugin/src/com/microsoft/alm/plugin/context/ServerContextManager.java#L737-L739

   The `serverUrl` returned by Azure API always already contained the account information in every case I've tested (e.g. it could return `https://dev.azure.com/username`), so there is no need to add the organization/account name to it, because it will result in erroneous `https://dev.azure.com/username/username`, which will result in 404 error being thrown.

   I've decided to delete this piece of code. The logging that has been added will help us to investigate the cases when it could've been necessary, if any.

Each of the issues gets solved by a corresponding commit in this PR, and I've done my best to make the commit messages descriptive and concise.