### PR TITLE
Logging improvements

### DIFF
--- a/plugin.idea/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeProvider.java
+++ b/plugin.idea/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeProvider.java
@@ -161,8 +161,6 @@ public class TFSChangeProvider implements ChangeProvider {
                     pathsToProcess.add(root.getPath());
                     break;
                 }
-
-                logger.debug("Ignoring the file because it is outside of any TFVC mapping: {}", root);
             }
         }
 

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
@@ -63,6 +63,7 @@ public abstract class Command<T> {
 
     private final String name;
     private final boolean useProxyIfAvailable;
+    private final boolean logStdOut;
 
     // The server context provides the server url and credentials for commands
     // Note that this may be null in some cases
@@ -90,13 +91,14 @@ public abstract class Command<T> {
     }
 
     public Command(final String name, final ServerContext context) {
-        this(name, context, true);
+        this(name, context, true, true);
     }
 
-    public Command(final String name, final ServerContext context, final boolean useProxyIfAvailable) {
+    public Command(final String name, final ServerContext context, final boolean useProxyIfAvailable, final boolean logStdOut) {
         this.name = name;
         this.context = context;
         this.useProxyIfAvailable = useProxyIfAvailable;
+        this.logStdOut = logStdOut;
     }
 
     public ToolRunner.ArgumentBuilder getArgumentBuilder() {
@@ -140,7 +142,10 @@ public abstract class Command<T> {
                 getArgumentBuilder(), new ToolRunner.Listener() {
                     @Override
                     public void processStandardOutput(final String line) {
-                        logger.info("CMD: " + line);
+                        if (logStdOut) {
+                            logger.info("CMD: " + line);
+                        }
+
                         stdout.append(line + "\n");
                         listener.progress(line, OUTPUT_TYPE_INFO, 50);
                     }

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/DownloadCommand.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/DownloadCommand.java
@@ -29,7 +29,7 @@ public class DownloadCommand extends Command<String> {
     private final boolean ignoreFileNotFound;
 
     public DownloadCommand(final ServerContext context, final String localPath, final int version, final String destination, final boolean ignoreFileNotFound) {
-        super("print", context);
+        super("print", context, true, false);
         ArgumentHelper.checkNotEmptyString(localPath, "localPath");
         ArgumentHelper.checkNotEmptyString(destination, "destination");
         this.localPath = localPath;


### PR DESCRIPTION
Removes excessive logging from the change provider and from the `print` command (aka `DownloadCommand`).

Closes #190.