### PR TITLE
Fixes for cases when external files are included into project content

### DIFF
--- a/plugin.idea/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSVcs.java
+++ b/plugin.idea/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSVcs.java
@@ -163,7 +163,7 @@ public class TFSVcs extends AbstractVcs {
     @NotNull
     public UpdateEnvironment createUpdateEnvironment() {
         if (myUpdateEnvironment == null) {
-            myUpdateEnvironment = new TFSUpdateEnvironment(this);
+            myUpdateEnvironment = new TFSUpdateEnvironment(myProject, this);
         }
         return myUpdateEnvironment;
     }

--- a/plugin.idea/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TFVCUtil.java
+++ b/plugin.idea/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TFVCUtil.java
@@ -15,22 +15,24 @@ import java.util.List;
 
 public class TFVCUtil {
 
+    public static boolean isFileUnderTFVCMapping(@NotNull Project project, FilePath filePath) {
+        List<FilePath> workspaceMappings = getMappingsFromWorkspace(project);
+        for (FilePath mappingPath : workspaceMappings) {
+            if (filePath.isUnder(mappingPath, false)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * Some commands (e.g. `tf status` or `tf get`) won't work if any of the paths passed don't belong to a workspace,
      * so we need to filter only the items belonging to a local workspace before passing arguments to these commands.
      */
     @NotNull
     public static List<String> filterValidTFVCPaths(@NotNull Project project, @NotNull Collection<FilePath> paths) {
-        Workspace workspace = CommandUtils.getPartialWorkspace(project);
-        if (workspace == null) {
-            return Collections.emptyList();
-        }
-
-        List<FilePath> mappingPaths = new ArrayList<FilePath>();
-        for (Workspace.Mapping mapping : workspace.getMappings()) {
-            mappingPaths.add(new LocalFilePath(mapping.getLocalPath(), true));
-        }
-
+        List<FilePath> mappingPaths = getMappingsFromWorkspace(project);
         List<String> pathsToProcess = new ArrayList<String>();
         for (FilePath path : paths) {
             // if we get a change notification in the $tf folder, we need to just ignore it
@@ -49,5 +51,19 @@ public class TFVCUtil {
         }
 
         return pathsToProcess;
+    }
+
+    private static List<FilePath> getMappingsFromWorkspace(@NotNull Project project) {
+        Workspace workspace = CommandUtils.getPartialWorkspace(project);
+        if (workspace == null) {
+            return Collections.emptyList();
+        }
+
+        List<FilePath> mappingPaths = new ArrayList<FilePath>();
+        for (Workspace.Mapping mapping : workspace.getMappings()) {
+            mappingPaths.add(new LocalFilePath(mapping.getLocalPath(), true));
+        }
+
+        return mappingPaths;
     }
 }

--- a/plugin.idea/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TFVCUtil.java
+++ b/plugin.idea/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TFVCUtil.java
@@ -1,0 +1,53 @@
+package com.microsoft.alm.plugin.idea.tfvc.core.tfs;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vcs.FilePath;
+import com.intellij.openapi.vcs.LocalFilePath;
+import com.microsoft.alm.plugin.external.models.Workspace;
+import com.microsoft.alm.plugin.external.utils.CommandUtils;
+import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public class TFVCUtil {
+
+    /**
+     * Some commands (e.g. `tf status` or `tf get`) won't work if any of the paths passed don't belong to a workspace,
+     * so we need to filter only the items belonging to a local workspace before passing arguments to these commands.
+     */
+    @NotNull
+    public static List<String> filterValidTFVCPaths(@NotNull Project project, @NotNull Collection<FilePath> paths) {
+        Workspace workspace = CommandUtils.getPartialWorkspace(project);
+        if (workspace == null) {
+            return Collections.emptyList();
+        }
+
+        List<FilePath> mappingPaths = new ArrayList<FilePath>();
+        for (Workspace.Mapping mapping : workspace.getMappings()) {
+            mappingPaths.add(new LocalFilePath(mapping.getLocalPath(), true));
+        }
+
+        List<String> pathsToProcess = new ArrayList<String>();
+        for (FilePath path : paths) {
+            // if we get a change notification in the $tf folder, we need to just ignore it
+            if (StringUtils.containsIgnoreCase(path.getPath(), "$tf") ||
+                    StringUtils.containsIgnoreCase(path.getPath(), ".tf")) {
+                continue;
+            }
+
+            // Ignore any files outside of a TFVC mapping:
+            for (FilePath mappingPath : mappingPaths) {
+                if (path.isUnder(mappingPath, false)) {
+                    pathsToProcess.add(path.getPath());
+                    break;
+                }
+            }
+        }
+
+        return pathsToProcess;
+    }
+}

--- a/plugin.idea/test/com/microsoft/alm/plugin/idea/tfvc/core/TFSCommittedChangesProviderTest.java
+++ b/plugin.idea/test/com/microsoft/alm/plugin/idea/tfvc/core/TFSCommittedChangesProviderTest.java
@@ -16,6 +16,7 @@ import com.microsoft.alm.plugin.external.models.ChangeSet;
 import com.microsoft.alm.plugin.external.models.Workspace;
 import com.microsoft.alm.plugin.external.utils.CommandUtils;
 import com.microsoft.alm.plugin.idea.IdeaAbstractTest;
+import com.microsoft.alm.plugin.idea.tfvc.core.tfs.TFVCUtil;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,10 +37,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({TFSVcs.class, CommandUtils.class, TFSCommittedChangesProvider.class})
+@PrepareForTest({TFSVcs.class, CommandUtils.class, TFSCommittedChangesProvider.class, TFVCUtil.class})
 public class TFSCommittedChangesProviderTest extends IdeaAbstractTest {
     private static final String SERVER_URL = "https://organization.visualstudio.com";
     private static final String LOCAL_ROOT_PATH = "/Users/user/root";
@@ -91,6 +93,9 @@ public class TFSCommittedChangesProviderTest extends IdeaAbstractTest {
         when(mockChangeSet1.getDate()).thenReturn("2016-08-15T11:50:09.427-0400");
         when(mockChangeSet2.getDate()).thenReturn("2016-07-11T12:00:00.000-0400");
         when(mockChangeSet3.getDate()).thenReturn("2016-06-23T04:30:00.00-0400");
+
+        mockStatic(TFVCUtil.class);
+        when(TFVCUtil.isFileUnderTFVCMapping(mockProject, mockRoot)).thenReturn(true);
 
         committedChangesProvider = new TFSCommittedChangesProvider(mockProject);
     }

--- a/plugin.idea/test/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TFVCUtilTest.java
+++ b/plugin.idea/test/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TFVCUtilTest.java
@@ -1,0 +1,77 @@
+package com.microsoft.alm.plugin.idea.tfvc.core.tfs;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vcs.FilePath;
+import com.intellij.openapi.vcs.LocalFilePath;
+import com.microsoft.alm.plugin.external.models.Workspace;
+import com.microsoft.alm.plugin.external.utils.CommandUtils;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({CommandUtils.class})
+public class TFVCUtilTest {
+
+    private final Workspace workspace = new Workspace(
+            "server",
+            "name",
+            "computer",
+            "owner",
+            "comment",
+            Arrays.asList(new Workspace.Mapping("serverPath", "/tmp/localPath", false)));
+
+    @Mock
+    private Project mockProject;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        PowerMockito.mockStatic(CommandUtils.class);
+        when(CommandUtils.getPartialWorkspace(mockProject)).thenReturn(workspace);
+    }
+
+    @Test
+    public void isFileUnderTFVCMappingShouldTests() {
+        Assert.assertTrue(TFVCUtil.isFileUnderTFVCMapping(mockProject, new LocalFilePath("/tmp/localPath/1.txt", false)));
+        Assert.assertTrue(TFVCUtil.isFileUnderTFVCMapping(mockProject, new LocalFilePath("/tmp/localPath", true)));
+        Assert.assertFalse(TFVCUtil.isFileUnderTFVCMapping(mockProject, new LocalFilePath("/tmp/localPath1", true)));
+        Assert.assertFalse(TFVCUtil.isFileUnderTFVCMapping(mockProject, new LocalFilePath("/tmp/localPath1/1.txt", false)));
+    }
+
+    @Test
+    public void filterValidTFVCPathsTest() {
+        List<FilePath> localFiles = Arrays.<FilePath>asList(
+                new LocalFilePath("/tmp/localPath", true),
+                new LocalFilePath("/tmp/localPath/1.txt", false));
+        List<FilePath> nonLocalFiles = Arrays.<FilePath>asList(
+                new LocalFilePath("/tmp/localPath1", true),
+                new LocalFilePath("/tmp/localPath1/1.txt", false));
+        List<FilePath> allPaths = Lists.newArrayList(Iterables.concat(localFiles, nonLocalFiles));
+        List<String> localFilePaths = Lists.transform(localFiles, new Function<FilePath, String>() {
+            @Override
+            public String apply(@Nullable FilePath input) {
+                return input.getPath();
+            }
+        });
+        assertThat(TFVCUtil.filterValidTFVCPaths(mockProject, allPaths), is(localFilePaths));
+    }
+}


### PR DESCRIPTION
Closes #173.

I've found a couple of additional cases when path filtering should be applied (so paths outside of TFVC workspace aren't passed to any TFS client commands).

Notably, to prevent the IDEA infrastructure from ignoring workspace parts other except the first one, I had to return `null` from `TFSCommittedChangesProvider::getLocationFor`. I believe that's the right solution for the issue (so it doesn't try to construct `TFSRepositoryLocation` instances for location outside of a TFS repository).