### PR TITLE
Fix for IDEA 2019.2 internal changes

### DIFF
--- a/plugin.idea/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSVcs.java
+++ b/plugin.idea/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSVcs.java
@@ -176,20 +176,12 @@ public class TFSVcs extends AbstractVcs {
         return isVersionedDirectory(filePath.getVirtualFile());
     }
 
-    /*
-    TODO:
-    public boolean isVersionedDirectory(final VirtualFile dir) {
-        if (dir == null) {
-            return false;
-        }
-        return (!Workstation.getInstance().findWorkspacesCached(TfsFileUtil.getFilePath(dir), false).isEmpty());
+    /**
+     * Overrides method from IDEA 2019.2 that will allow us to work without "new" root mappings.
+     */
+    public boolean needsLegacyDefaultMappings() {
+        return true;
     }
-
-
-    public EditFileProvider getEditFileProvider() {
-        return new TFSEditFileProvider(myProject);
-    }
-    */
 
     @NotNull
     public CommittedChangesProvider<TFSChangeList, ChangeBrowserSettings> getCommittedChangesProvider() {


### PR DESCRIPTION
Otherwise, we won't be able to work in 2019.2 onward.

I have another, more proper fix prepared in branch [bugfix/2019.2](https://github.com/JetBrains/azure-devops-intellij/tree/bugfix/2019.2), but for now I think we'll use this `needsLegacyDefaultMappings` instead, because proper fix involves caching stuff and calling `tf` client a lot, and thus could decrease performance and even break user experience (in case the cache becomes invalid).