### PR TITLE
Migrate to Java 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Once you've downloaded the dependencies, run the build by:
        * Under Linux, the folder is similar to `<IntelliJ installation location on disk>/idea-IC-172.3968.16` 
        * Under Windows, the folder is similar to `C:\Program Files (x86)\JetBrains\IntelliJ IDEA 2017.x`
 
-3. Configure the project to use language level JDK 6
+3. Configure the project to use language level JDK 8
    * File -> Project Structure -> Project Settings -> Project
-   * Under Project Language Level, select "6 - @Override in interface"
+   * Under Project Language Level, select "8 - Lambdas, type annotations etc."
 
 4. Configure the project and ***each module*** to build with this "IntelliJ Platform Plugin SDK".
    * File -> Project Structure -> Project Settings -> Project.

--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,8 @@ subprojects {
     apply plugin: 'findbugs'
 
 
-    sourceCompatibility = 1.6
-    targetCompatibility = 1.6
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 
     task unitTest(type: Test) {
         exclude '**/L2/**'

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/ui/common/ServerContextTableModel.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/ui/common/ServerContextTableModel.java
@@ -4,7 +4,6 @@
 package com.microsoft.alm.plugin.idea.common.ui.common;
 
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 import com.microsoft.alm.common.utils.UrlHelper;
@@ -15,7 +14,6 @@ import com.microsoft.alm.plugin.idea.common.resources.TfPluginBundle;
 import com.microsoft.alm.plugin.idea.common.utils.VcsHelper;
 import com.microsoft.alm.sourcecontrol.webapi.model.GitRepository;
 import org.apache.commons.lang.StringUtils;
-import org.jetbrains.annotations.Nullable;
 
 import javax.swing.DefaultListSelectionModel;
 import javax.swing.ListSelectionModel;
@@ -300,17 +298,7 @@ public class ServerContextTableModel extends AbstractTableModel {
         if (!hasFilter()) {
             filteredRows = null;
         } else {
-            filteredRows = Lists.newArrayList(Collections2.filter(rows, new Predicate<ServerContext>() {
-                @Override
-                public boolean apply(ServerContext repositoryRow) {
-                    return rowContains(repositoryRow);
-                }
-
-                @Override
-                public boolean test(@Nullable ServerContext input) {
-                    return apply(input);
-                }
-            }));
+            filteredRows = Lists.newArrayList(Collections2.filter(rows, this::rowContains));
         }
         super.fireTableDataChanged();
     }

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/ui/workitem/WorkItemsTableModel.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/ui/workitem/WorkItemsTableModel.java
@@ -4,7 +4,6 @@
 package com.microsoft.alm.plugin.idea.common.ui.workitem;
 
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 import com.microsoft.alm.common.utils.SystemHelper;
@@ -12,7 +11,6 @@ import com.microsoft.alm.plugin.idea.common.ui.common.FilteredModel;
 import com.microsoft.alm.plugin.idea.common.ui.common.TableModelSelectionConverter;
 import com.microsoft.alm.workitemtracking.webapi.models.WorkItem;
 import org.apache.commons.lang.StringUtils;
-import org.jetbrains.annotations.Nullable;
 
 import javax.swing.DefaultListSelectionModel;
 import javax.swing.ListSelectionModel;
@@ -237,17 +235,7 @@ public class WorkItemsTableModel extends AbstractTableModel implements FilteredM
         if (!hasFilter()) {
             filteredRows = null;
         } else {
-            filteredRows = Lists.newArrayList(Collections2.filter(rows, new Predicate<WorkItem>() {
-                @Override
-                public boolean apply(WorkItem item) {
-                    return rowContains(item);
-                }
-
-                @Override
-                public boolean test(@Nullable WorkItem input) {
-                    return apply(input);
-                }
-            }));
+            filteredRows = Lists.newArrayList(Collections2.filter(rows, this::rowContains));
         }
         super.fireTableDataChanged();
     }

--- a/plugin/src/com/microsoft/alm/plugin/idea/git/ui/branch/CreateBranchModel.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/ui/branch/CreateBranchModel.java
@@ -3,7 +3,6 @@
 
 package com.microsoft.alm.plugin.idea.git.ui.branch;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.notification.Notification;
@@ -37,7 +36,6 @@ import git4idea.update.GitFetchResult;
 import git4idea.update.GitFetcher;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,19 +88,10 @@ public class CreateBranchModel extends AbstractModel {
 
         // TODO: add option to retrieve more branches in case the branch they are looking for is missing local
         // only show valid remote branches
-        sortedRemoteBranches.addAll(Collections2.filter(gitRepository.getInfo().getRemoteBranches(), new Predicate<GitRemoteBranch>() {
-                    @Override
-                    public boolean apply(final GitRemoteBranch remoteBranch) {
-                        //  condition: remote must be a vso/tfs remote
-                        return tfGitRemotes.contains(remoteBranch.getRemote());
-                    }
-
-                    @Override
-                    public boolean test(@Nullable GitRemoteBranch input) {
-                        return apply(input);
-                    }
-                })
-        );
+        sortedRemoteBranches.addAll(Collections2.filter(gitRepository.getInfo().getRemoteBranches(), remoteBranch -> {
+            //  condition: remote must be a vso/tfs remote
+            return tfGitRemotes.contains(remoteBranch.getRemote());
+        }));
         sortedRemoteBranches.setSelectedItem(TfGitHelper.getDefaultBranch(sortedRemoteBranches.getItems(), tfGitRemotes));
         return sortedRemoteBranches;
     }

--- a/plugin/src/com/microsoft/alm/plugin/idea/git/ui/pullrequest/CreatePullRequestModel.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/ui/pullrequest/CreatePullRequestModel.java
@@ -3,7 +3,6 @@
 
 package com.microsoft.alm.plugin.idea.git.ui.pullrequest;
 
-import com.google.common.base.Predicate;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -273,22 +272,14 @@ public class CreatePullRequestModel extends AbstractModel {
 
         // only show valid remote branches
         sortedRemoteBranches.addAll(Collections2.filter(getInfo().getRemoteBranches(),
-                        new Predicate<GitRemoteBranch>() {
-                            @Override
-                            public boolean apply(final GitRemoteBranch remoteBranch) {
-                        /* two conditions:
-                         *   1. remote must be a vso/tfs remote
-                         *   2. this isn't the remote tracking branch of current local branch
-                         */
-                                return tfGitRemotes.contains(remoteBranch.getRemote())
-                                        && !remoteBranch.equals(remoteTrackingBranch);
-                            }
-
-                            @Override
-                            public boolean test(@Nullable GitRemoteBranch input) {
-                                return apply(input);
-                            }
-                        })
+                remoteBranch -> {
+                    /* two conditions:
+                     *   1. remote must be a vso/tfs remote
+                     *   2. this isn't the remote tracking branch of current local branch
+                     */
+                    return tfGitRemotes.contains(remoteBranch.getRemote())
+                            && !remoteBranch.equals(remoteTrackingBranch);
+                })
         );
         sortedRemoteBranches.setSelectedItem(TfGitHelper.getDefaultBranch(sortedRemoteBranches.getItems(), tfGitRemotes));
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/git/utils/TfGitHelper.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/utils/TfGitHelper.java
@@ -3,7 +3,6 @@
 
 package com.microsoft.alm.plugin.idea.git.utils;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
@@ -86,17 +85,7 @@ public class TfGitHelper {
         assert gitRepository != null;
         Collection<GitRemote> gitRemotes = gitRepository.getRemotes();
 
-        return Collections2.filter(gitRemotes, new Predicate<GitRemote>() {
-            @Override
-            public boolean apply(final GitRemote remote) {
-                return TfGitHelper.isTfGitRemote(remote);
-            }
-
-            @Override
-            public boolean test(@Nullable GitRemote input) {
-                return apply(input);
-            }
-        });
+        return Collections2.filter(gitRemotes, TfGitHelper::isTfGitRemote);
     }
 
     public static GitRepository getTfGitRepository(@NotNull final Project project) {


### PR DESCRIPTION
We're already using some APIs from JDK8, so this won't break any compatibility.

I've also removed the most ridiculous pieces of code we had to add earlier when working with Guava functional interfaces.