### PR TITLE
Fix for "illegal dollars" in paths

### DIFF
--- a/plugin/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
+++ b/plugin/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
@@ -43,6 +43,7 @@ Errors.UnableToDetermineWorkspace=Unable to determine the workspace for the proj
 TFS.ServerPath.Invalid=Invalid server path detected: ''{0}''
 
 #Tool Exception messages
+ToolException.TF.DollarInPath=Path starts with ''$'': ''{0}''.\nTFVC client will not work properly until this file is ignored.
 ToolException.TF.HomeNotSet=The TF command line tool must be installed and the location identified in the <a href='settings'>Settings</a>.
 ToolException.TF.ExeNotFound=The specified path does not lead to a valid TF executable.
 ToolException.TF.BadExitCode=TF command returned non-zero exit code. Exit code = {0}

--- a/plugin/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
+++ b/plugin/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
@@ -373,9 +373,11 @@ Plugin.Error.GitExeNotConfigured=The Azure DevOps plugin requires Git settings t
 Plugin.Error.TFNotConfigured=The TF command line tool must be installed and the location identified in the Settings menu.
 Plugin.Error.TFNotConfiguredDialog.OpenSettings=Open Settings
 Plugin.Error.TFNotConfiguredDialog.Cancel=Cancel
+Plugin.TfvcNotifications=TFVC Notifications
 
 #TFVC
 Tfvc.Add.Scheduling=Scheduling addition...
+Tfvc.Action.AddToTfIgnore=Add to .tfignore
 Tfvc.Delete.Scheduling=Scheduling deletion...
 Tfvc.Add.Error=The following files were not successfully added\: {0}
 Tfvc.Add.Item=Add Item to TFVC
@@ -386,6 +388,7 @@ Tfvc.Checkin.Successful.Title=Checkin Successful
 Tfvc.Checkin.Successful.Msg=Successfully created {0}
 Tfvc.Checkin.Link.Text=Changeset #{0}
 Tfvc.Checkin.Status=Checking in files...
+Tfvc.Notification.FileNameStartsWithDollar=File name starts with '$', TFVC client will not work properly until this file is ignored\: {0}
 Tfvc.Update.Status.Msg=Updating files...
 Tfvc.tf.VersionWarning.Progress=Checking the version of the TF command line...
 Tfvc.tf.VersionWarning.Title=TFVC Command Line

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
@@ -54,6 +54,7 @@ public abstract class Command<T> {
     private static final Logger logger = LoggerFactory.getLogger(Command.class);
 
     private static final Pattern CHANGESET_NUMBER_PATTERN = Pattern.compile("#(\\d+)");
+    private static final Pattern INVALID_DOLLAR_PATH_PATTERN = Pattern.compile("TF10122: The path '(.*?)' contains a '\\$' at the beginning of a path component. Remove the '\\$' and try again.");
 
     public static final int OUTPUT_TYPE_INFO = 0;
     public static final int OUTPUT_TYPE_WARNING = 1;
@@ -401,6 +402,18 @@ public abstract class Command<T> {
         }
 
         return Path.combine(folderPath, filename);
+    }
+
+    static void checkStderrForInvalidDollarPath(String stderr) {
+        Matcher matcher = INVALID_DOLLAR_PATH_PATTERN.matcher(stderr);
+        if (!matcher.find()) {
+            return;
+        }
+
+        String serverFilePath = matcher.group(1);
+        if (StringUtils.isNotEmpty(serverFilePath)) {
+            throw new DollarInPathException(serverFilePath);
+        }
     }
 
     protected void throwIfError(final String stderr) {

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
@@ -10,6 +10,7 @@ import com.microsoft.alm.helpers.Path;
 import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.external.ToolRunner;
 import com.microsoft.alm.plugin.external.ToolRunnerCache;
+import com.microsoft.alm.plugin.external.exceptions.DollarInPathException;
 import com.microsoft.alm.plugin.external.exceptions.ToolException;
 import com.microsoft.alm.plugin.external.exceptions.ToolMemoryException;
 import com.microsoft.alm.plugin.external.exceptions.ToolParseFailureException;
@@ -238,6 +239,7 @@ public abstract class Command<T> {
                     throw new ToolEulaNotAcceptedException(error);
                 }
                 if (error instanceof RuntimeException) {
+                    logger.error("Error: {}\nSync stack trace: {}", error, StringUtils.join(Thread.currentThread().getStackTrace(), "\n    at "));
                     throw (RuntimeException) error;
                 } else {
                     // Wrap the exception
@@ -246,10 +248,7 @@ public abstract class Command<T> {
             } else {
                 return syncResult.get();
             }
-        } catch (InterruptedException e) {
-            logger.error("CMD: failure", e);
-            throw new ToolException(ToolException.KEY_TF_BAD_EXIT_CODE, e);
-        } catch (ExecutionException e) {
+        } catch (InterruptedException | ExecutionException e) {
             logger.error("CMD: failure", e);
             throw new ToolException(ToolException.KEY_TF_BAD_EXIT_CODE, e);
         } finally {

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/StatusCommand.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/StatusCommand.java
@@ -63,7 +63,7 @@ public class StatusCommand extends Command<List<PendingChange>> {
      */
     @Override
     public List<PendingChange> parseOutput(final String stdout, final String stderr) {
-        super.throwIfError(stderr);
+        throwIfError(stderr);
         final List<PendingChange> changes = new ArrayList<PendingChange>(100);
         final NodeList nodes = super.evaluateXPath(stdout, "/status/*/pending-change");
 
@@ -88,5 +88,11 @@ public class StatusCommand extends Command<List<PendingChange>> {
             }
         }
         return changes;
+    }
+
+    @Override
+    protected void throwIfError(String stderr) {
+        checkStderrForInvalidDollarPath(stderr);
+        super.throwIfError(stderr);
     }
 }

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/SyncCommand.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/SyncCommand.java
@@ -100,6 +100,8 @@ public class SyncCommand extends Command<SyncResults> {
      */
     @Override
     public SyncResults parseOutput(final String stdout, final String stderr) {
+        checkStderrForInvalidDollarPath(stderr);
+
         final List<String> updatedFiles = new ArrayList<String>();
         final List<String> newFiles = new ArrayList<String>();
         final List<String> deletedFiles = new ArrayList<String>();

--- a/plugin/src/com/microsoft/alm/plugin/external/exceptions/DollarInPathException.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/exceptions/DollarInPathException.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
 package com.microsoft.alm.plugin.external.exceptions;
 
 import org.jetbrains.annotations.NotNull;

--- a/plugin/src/com/microsoft/alm/plugin/external/exceptions/DollarInPathException.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/exceptions/DollarInPathException.java
@@ -1,0 +1,28 @@
+package com.microsoft.alm.plugin.external.exceptions;
+
+import org.jetbrains.annotations.NotNull;
+
+public class DollarInPathException extends ToolException {
+    @NotNull
+    private final String myServerFilePath;
+
+    public DollarInPathException(@NotNull String fileName) {
+        super(KEY_TF_DOLLAR_IN_PATH);
+        this.myServerFilePath = fileName;
+    }
+
+    @Override
+    public String getMessage() {
+        return "'$' was found in path component: " + myServerFilePath;
+    }
+
+    @NotNull
+    public String getServerFilePath() {
+        return myServerFilePath;
+    }
+
+    @Override
+    public String[] getMessageParameters() {
+        return new String[]{myServerFilePath};
+    }
+}

--- a/plugin/src/com/microsoft/alm/plugin/external/exceptions/ToolException.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/exceptions/ToolException.java
@@ -35,6 +35,7 @@ public class ToolException extends RuntimeException implements LocalizedExceptio
     }
 
     // Keys for tool exception messages
+    public static String KEY_TF_DOLLAR_IN_PATH = "KEY_TF_DOLLAR_IN_PATH";
     public static String KEY_TF_HOME_NOT_SET = "KEY_TF_HOME_NOT_SET";
     public static String KEY_TF_EXE_NOT_FOUND = "KEY_TF_EXE_NOT_FOUND";
     public static String KEY_TF_BAD_EXIT_CODE = "KEY_TF_BAD_EXIT_CODE";

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/resources/TfPluginBundle.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/resources/TfPluginBundle.java
@@ -59,6 +59,8 @@ public class TfPluginBundle {
     public static final String KEY_TFVC_NOT_CONFIGURED_DIALOG_OPEN_SETTINGS = "Plugin.Error.TFNotConfiguredDialog.OpenSettings";
     @NonNls
     public static final String KEY_TFVC_NOT_CONFIGURED_DIALOG_CANCEL = "Plugin.Error.TFNotConfiguredDialog.Cancel";
+    @NonNls
+    public static final String KEY_TFVC_NOTIFICATIONS = "Plugin.TfvcNotifications";
 
     // Login form
     @NonNls
@@ -105,10 +107,14 @@ public class TfPluginBundle {
     public static final String KEY_ERRORS_NOT_TFS_REPO = "Errors.NotTfsRepo";
     @NonNls
     public static final String KEY_VSO_NO_PROFILE_ERROR_HELP = "VSO.NoProfileError.Help";
+    @NonNls
+    public static final String KEY_TFVC_NOTIFICATION_FILE_NAME_STARTS_WITH_DOLLAR = "Tfvc.Notification.FileNameStartsWithDollar";
 
     // Common TFVC
     @NonNls
     public static final String KEY_ERRORS_UNABLE_TO_DETERMINE_WORKSPACE = "Errors.UnableToDetermineWorkspace";
+    @NonNls
+    public static final String KEY_TFVC_ACTION_ADD_TO_TFIGNORE = "Tfvc.Action.AddToTfIgnore";
 
     // Checkout dialog ui and models
     @NonNls

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/services/LocalizationServiceImpl.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/services/LocalizationServiceImpl.java
@@ -93,6 +93,7 @@ public class LocalizationServiceImpl implements LocalizationService {
 
             // Tool Exception messages
             put(ToolException.KEY_TF_BAD_EXIT_CODE, "ToolException.TF.BadExitCode");
+            put(ToolException.KEY_TF_DOLLAR_IN_PATH, "ToolException.TF.DollarInPath");
             put(ToolException.KEY_TF_HOME_NOT_SET, "ToolException.TF.HomeNotSet");
             put(ToolException.KEY_TF_EXE_NOT_FOUND, "ToolException.TF.ExeNotFound");
             put(ToolException.KEY_TF_PARSE_FAILURE, "ToolException.TF.ParseFailure");

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/AddFileToTfIgnoreAction.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/AddFileToTfIgnoreAction.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
 package com.microsoft.alm.plugin.idea.tfvc.actions;
 
 import com.intellij.openapi.actionSystem.AnAction;

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/AddFileToTfIgnoreAction.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/AddFileToTfIgnoreAction.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.vcs.changes.actions.RefreshAction;
 import com.intellij.util.ObjectUtils;
 import com.microsoft.alm.plugin.external.models.Workspace;
 import com.microsoft.alm.plugin.external.utils.CommandUtils;
+import com.microsoft.alm.plugin.idea.common.resources.TfPluginBundle;
 import com.microsoft.alm.plugin.idea.tfvc.core.tfs.TfIgnoreUtil;
 import com.microsoft.alm.plugin.idea.tfvc.core.tfs.TfsFileUtil;
 import org.jetbrains.annotations.NotNull;
@@ -27,7 +28,7 @@ public class AddFileToTfIgnoreAction extends AnAction {
     private final String myServerFilePath;
 
     public AddFileToTfIgnoreAction(@NotNull Project project, @NotNull String serverFilePath) {
-        super("Add to .tfignore");
+        super(TfPluginBundle.message(TfPluginBundle.KEY_TFVC_ACTION_ADD_TO_TFIGNORE));
         myProject = project;
         myServerFilePath = serverFilePath;
     }

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/AddFileToTfIgnoreAction.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/AddFileToTfIgnoreAction.java
@@ -1,0 +1,61 @@
+package com.microsoft.alm.plugin.idea.tfvc.actions;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.command.CommandProcessor;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vcs.changes.actions.RefreshAction;
+import com.intellij.util.ObjectUtils;
+import com.microsoft.alm.plugin.external.models.Workspace;
+import com.microsoft.alm.plugin.external.utils.CommandUtils;
+import com.microsoft.alm.plugin.idea.tfvc.core.tfs.TfIgnoreUtil;
+import com.microsoft.alm.plugin.idea.tfvc.core.tfs.TfsFileUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+
+public class AddFileToTfIgnoreAction extends AnAction {
+    private static final Logger LOGGER = Logger.getInstance(AddFileToTfIgnoreAction.class);
+
+    @NotNull
+    private final Project myProject;
+
+    @NotNull
+    private final String myServerFilePath;
+
+    public AddFileToTfIgnoreAction(@NotNull Project project, @NotNull String serverFilePath) {
+        super("Add to .tfignore");
+        myProject = project;
+        myServerFilePath = serverFilePath;
+    }
+
+    @Override
+    public void actionPerformed(AnActionEvent e) {
+        Workspace partialWorkspace = CommandUtils.getPartialWorkspace(myProject);
+        String filePath = ObjectUtils.assertNotNull(
+                TfsFileUtil.translateServerItemToLocalItem(partialWorkspace.getMappings(), myServerFilePath, false));
+        File localFile = new File(filePath);
+
+        File tfIgnore = TfIgnoreUtil.findNearestOrRootTfIgnore(partialWorkspace.getMappings(), localFile);
+        if (tfIgnore != null) {
+            CommandProcessor.getInstance().executeCommand(
+                    myProject,
+                    () -> ApplicationManager.getApplication().runWriteAction(() -> {
+                        try {
+                            TfIgnoreUtil.addToTfIgnore(this, tfIgnore, localFile);
+                        } catch (IOException ex) {
+                            LOGGER.error(ex);
+                        }
+                    }),
+                    null,
+                    null);
+
+            // Usually the TFVC is already in a bad state (i.e. all the changed files are lost) before this action gets
+            // called, so we need to refresh the VCS changes afterwards.
+            RefreshAction.doRefresh(myProject);
+        }
+    }
+}

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeProvider.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeProvider.java
@@ -30,6 +30,7 @@ import com.intellij.openapi.vcs.changes.ChangelistBuilder;
 import com.intellij.openapi.vcs.changes.VcsDirtyScope;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.microsoft.alm.plugin.external.commands.ToolEulaNotAcceptedException;
+import com.microsoft.alm.plugin.external.exceptions.DollarInPathException;
 import com.microsoft.alm.plugin.external.models.PendingChange;
 import com.microsoft.alm.plugin.external.utils.CommandUtils;
 import com.microsoft.alm.plugin.idea.common.utils.IdeaHelper;
@@ -107,6 +108,10 @@ public class TFSChangeProvider implements ChangeProvider {
         List<PendingChange> changes;
         try {
             changes = CommandUtils.getStatusForFiles(null, pathsToProcess);
+        } catch (DollarInPathException e) {
+            logger.warn("'$' sign in file path detected: {}. Ignoring any files.", e.getServerFilePath());
+            TFVCNotifications.showInvalidDollarFilePathNotification(myProject, e.getServerFilePath());
+            return;
         } catch (final ToolEulaNotAcceptedException e) {
             logger.error("EULA not accepted");
             IdeaHelper.runOnUIThread(new Runnable() {

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFVCNotifications.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFVCNotifications.java
@@ -6,19 +6,20 @@ import com.intellij.notification.NotificationGroup;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.project.Project;
+import com.microsoft.alm.plugin.idea.common.resources.TfPluginBundle;
 import com.microsoft.alm.plugin.idea.tfvc.actions.AddFileToTfIgnoreAction;
 import org.jetbrains.annotations.NotNull;
 
 public class TFVCNotifications {
     private static final NotificationGroup TFS_NOTIFICATIONS = new NotificationGroup(
-            "TFVC Notifications",
+            TfPluginBundle.message(TfPluginBundle.KEY_TFVC_NOTIFICATIONS),
             NotificationDisplayType.BALLOON,
             true
     );
 
     public static void showInvalidDollarFilePathNotification(@NotNull Project project, @NotNull String serverFilePath) {
         Notification notification = TFS_NOTIFICATIONS.createNotification(
-                "File name starts with '$', TFVC client will not work properly until this file is ignored: " + serverFilePath,
+                TfPluginBundle.message(TfPluginBundle.KEY_TFVC_NOTIFICATION_FILE_NAME_STARTS_WITH_DOLLAR, serverFilePath),
                 NotificationType.WARNING);
         notification.addAction(new AddFileToTfIgnoreAction(project, serverFilePath));
         Notifications.Bus.notify(notification);

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFVCNotifications.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFVCNotifications.java
@@ -1,0 +1,26 @@
+package com.microsoft.alm.plugin.idea.tfvc.core;
+
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationDisplayType;
+import com.intellij.notification.NotificationGroup;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.project.Project;
+import com.microsoft.alm.plugin.idea.tfvc.actions.AddFileToTfIgnoreAction;
+import org.jetbrains.annotations.NotNull;
+
+public class TFVCNotifications {
+    private static final NotificationGroup TFS_NOTIFICATIONS = new NotificationGroup(
+            "TFVC Notifications",
+            NotificationDisplayType.BALLOON,
+            true
+    );
+
+    public static void showInvalidDollarFilePathNotification(@NotNull Project project, @NotNull String serverFilePath) {
+        Notification notification = TFS_NOTIFICATIONS.createNotification(
+                "File name starts with '$', TFVC client will not work properly until this file is ignored: " + serverFilePath,
+                NotificationType.WARNING);
+        notification.addAction(new AddFileToTfIgnoreAction(project, serverFilePath));
+        Notifications.Bus.notify(notification);
+    }
+}

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFVCNotifications.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFVCNotifications.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
 package com.microsoft.alm.plugin.idea.tfvc.core;
 
 import com.intellij.notification.Notification;

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TfIgnoreUtil.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TfIgnoreUtil.java
@@ -1,0 +1,91 @@
+package com.microsoft.alm.plugin.idea.tfvc.core.tfs;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.vcs.LocalFilePath;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileEvent;
+import com.intellij.util.ObjectUtils;
+import com.microsoft.alm.plugin.external.models.Workspace;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class TfIgnoreUtil {
+    public static final String TFIGNORE_FILE_NAME = ".tfignore";
+
+    /**
+     * Will find existing .tfignore file that is near the target file. If .tfignore doesn't exists, then the location
+     * will be proposed.
+     *
+     * @param mappings workspace mappings (to properly determine root location)
+     * @param file target file
+     * @return path to .tfignore (not necessary an existing file); will return null if place to create .tfignore was not
+     * found
+     */
+    @Nullable
+    public static File findNearestOrRootTfIgnore(@NotNull List<Workspace.Mapping> mappings, @NotNull File file) {
+        List<LocalFilePath> localRoots = mappings.stream()
+                .map(m -> new LocalFilePath(m.getLocalPath(), Files.isDirectory(Paths.get(m.getLocalPath()))))
+                .collect(Collectors.toList());
+        File potentialTfIgnore = null;
+        while (file != null) {
+            if (file.isDirectory()) {
+                LocalFilePath filePath = new LocalFilePath(file.getAbsolutePath(), true);
+                if (localRoots.stream().noneMatch(root -> filePath.isUnder(root, false))) {
+                    // Path is not under any of the root mappings; return last potential tfignore location that was under
+                    // mapping.
+                    return potentialTfIgnore;
+                }
+
+                potentialTfIgnore = new File(FileUtil.join(file.getAbsolutePath(), TFIGNORE_FILE_NAME));
+                if (potentialTfIgnore.isFile()) {
+                    return potentialTfIgnore;
+                }
+            }
+
+            file = file.getParentFile();
+        }
+
+        // We've ended at the file system root; finish here.
+        return null;
+    }
+
+    /**
+     * Adds an item into the .tfignore file.
+     * @param requestor an object that requested the change; see {@link VirtualFileEvent#getRequestor}
+     * @param tfIgnore a {@link File} object representing the .tfignore file
+     * @param fileToIgnore a file to ignore
+     */
+    public static void addToTfIgnore(@NotNull Object requestor, @NotNull File tfIgnore, @NotNull File fileToIgnore) throws IOException {
+        String relativePath = FileUtil.getRelativePath(tfIgnore.getParentFile(), fileToIgnore);
+        VirtualFile virtualTfIgnoreFile = LocalFileSystem.getInstance().findFileByIoFile(tfIgnore);
+        if (virtualTfIgnoreFile == null) {
+            VirtualFile parentDir = ObjectUtils.assertNotNull(  // should never be null because of the way we work with .tfignore
+                    LocalFileSystem.getInstance().findFileByIoFile(tfIgnore.getParentFile()));
+            virtualTfIgnoreFile = parentDir.createChildData(requestor, TFIGNORE_FILE_NAME);
+        }
+
+        addLineToFile(virtualTfIgnoreFile, relativePath);
+    }
+
+    private static void addLineToFile(VirtualFile file, String line) {
+        FileDocumentManager fileDocumentManager = FileDocumentManager.getInstance();
+        Document document = ObjectUtils.assertNotNull(fileDocumentManager.getDocument(file));
+        CharSequence contents = document.getCharsSequence();
+        if (!StringUtils.isEmpty(contents) && !StringUtils.endsWith(contents, "\n")) {
+            document.insertString(contents.length(), "\n");
+        }
+        document.insertString(document.getTextLength(), line);
+        fileDocumentManager.saveDocument(document);
+    }
+}

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TfIgnoreUtil.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TfIgnoreUtil.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
 package com.microsoft.alm.plugin.idea.tfvc.core.tfs;
 
 import com.intellij.openapi.editor.Document;

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TfIgnoreUtil.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TfIgnoreUtil.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,7 +34,7 @@ public class TfIgnoreUtil {
      * found
      */
     @Nullable
-    public static File findNearestOrRootTfIgnore(@NotNull List<Workspace.Mapping> mappings, @NotNull File file) {
+    public static File findNearestOrRootTfIgnore(@NotNull Collection<Workspace.Mapping> mappings, @NotNull File file) {
         List<LocalFilePath> localRoots = mappings.stream()
                 .map(m -> new LocalFilePath(m.getLocalPath(), Files.isDirectory(Paths.get(m.getLocalPath()))))
                 .collect(Collectors.toList());

--- a/plugin/src/com/microsoft/alm/plugin/versioncontrol/path/LocalPath.java
+++ b/plugin/src/com/microsoft/alm/plugin/versioncontrol/path/LocalPath.java
@@ -230,7 +230,7 @@ public abstract class LocalPath {
 
         // Checks for illegal dollar
         return ServerPath.canonicalize(
-                serverRoot + ServerPath.PREFERRED_SEPARATOR_CHARACTER + relativeBuffer.toString());
+                serverRoot + ServerPath.PREFERRED_SEPARATOR_CHARACTER + relativeBuffer.toString(), true);
     }
 
     /**

--- a/plugin/test/com/microsoft/alm/plugin/external/commands/StatusCommandTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/external/commands/StatusCommandTest.java
@@ -5,6 +5,7 @@ package com.microsoft.alm.plugin.external.commands;
 
 import com.google.common.collect.ImmutableList;
 import com.microsoft.alm.plugin.external.ToolRunner;
+import com.microsoft.alm.plugin.external.exceptions.DollarInPathException;
 import com.microsoft.alm.plugin.external.models.PendingChange;
 import com.microsoft.alm.plugin.external.models.ServerStatusType;
 import org.junit.Assert;
@@ -96,5 +97,11 @@ public class StatusCommandTest extends AbstractCommandTest {
     public void testParseOutput_errors() {
         final StatusCommand cmd = new StatusCommand(null, "/localpath");
         final List<PendingChange> pendingChanges = cmd.parseOutput("/path/path", "error");
+    }
+
+    @Test(expected = DollarInPathException.class)
+    public void testParseOutput_dollar() {
+        StatusCommand cmd = new StatusCommand(null, "/localpath");
+        List<PendingChange> pendingChanges = cmd.parseOutput("/path/path", "An input validation error occurred: TF10122: The path '$/serverpath' contains a '$' at the beginning of a path component. Remove the '$' and try again.");
     }
 }

--- a/plugin/test/com/microsoft/alm/plugin/external/commands/SyncCommandTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/external/commands/SyncCommandTest.java
@@ -4,6 +4,7 @@
 package com.microsoft.alm.plugin.external.commands;
 
 import com.microsoft.alm.plugin.external.ToolRunner;
+import com.microsoft.alm.plugin.external.exceptions.DollarInPathException;
 import com.microsoft.alm.plugin.external.models.SyncResults;
 import org.junit.Assert;
 import org.junit.Test;
@@ -151,5 +152,11 @@ public class SyncCommandTest extends AbstractCommandTest {
         Assert.assertEquals(1, results.getNewFiles().size());
         Assert.assertEquals(0, results.getUpdatedFiles().size());
         Assert.assertEquals(stderr, results.getExceptions().get(0).getMessage());
+    }
+
+    @Test(expected = DollarInPathException.class)
+    public void testParseOutput_dollar() {
+        SyncCommand cmd = new SyncCommand(null, files, false);
+        SyncResults results = cmd.parseOutput("/path/path", "An input validation error occurred: TF10122: The path '$/serverpath' contains a '$' at the beginning of a path component. Remove the '$' and try again.\n");
     }
 }

--- a/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TfIgnoreUtilTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TfIgnoreUtilTest.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
 package com.microsoft.alm.plugin.idea.tfvc.core.tfs;
 
 import com.microsoft.alm.plugin.external.models.Workspace;

--- a/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TfIgnoreUtilTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TfIgnoreUtilTest.java
@@ -1,0 +1,68 @@
+package com.microsoft.alm.plugin.idea.tfvc.core.tfs;
+
+import com.microsoft.alm.plugin.external.models.Workspace;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class TfIgnoreUtilTest {
+
+    @Test
+    public void findRootTfIgnore() throws IOException {
+        Path root = createTempFileSystem("root/project/node_modules/test.txt");
+        Path projectRoot = root.resolve("root/project");
+        Path textFile = projectRoot.resolve("node_modules/test.txt");
+        Workspace.Mapping mapping = new Workspace.Mapping("$/", projectRoot.toString(), false);
+
+        File tfIgnore = TfIgnoreUtil.findNearestOrRootTfIgnore(Collections.singleton(mapping), textFile.toFile());
+
+        File expectedTfIgnore = projectRoot.resolve(".tfignore").toFile();
+        assertEquals(expectedTfIgnore, tfIgnore);
+    }
+
+    @Test
+    public void findTfIgnoreInTheSameDirectory() throws IOException {
+        Path root = createTempFileSystem("root/project/node_modules/test.txt", "root/project/node_modules/.tfignore");
+        Path projectRoot = root.resolve("root/project");
+        Path textFile = projectRoot.resolve("node_modules/test.txt");
+        Workspace.Mapping mapping = new Workspace.Mapping("$/", projectRoot.toString(), false);
+
+        File tfIgnore = TfIgnoreUtil.findNearestOrRootTfIgnore(Collections.singleton(mapping), textFile.toFile());
+
+        File expectedTfIgnore = projectRoot.resolve("node_modules/.tfignore").toFile();
+        assertEquals(expectedTfIgnore, tfIgnore);
+    }
+
+    @Test
+    public void findTfIgnoreInNearestDirectory() throws IOException {
+        Path root = createTempFileSystem("root/project/src/node_modules/test.txt", "root/project/src/.tfignore");
+        Path projectRoot = root.resolve("root/project");
+        Path textFile = projectRoot.resolve("src/node_modules/src/node_modules/test.txt");
+        Workspace.Mapping mapping = new Workspace.Mapping("$/", projectRoot.toString(), false);
+
+        File tfIgnore = TfIgnoreUtil.findNearestOrRootTfIgnore(Collections.singleton(mapping), textFile.toFile());
+
+        File expectedTfIgnore = projectRoot.resolve("src/.tfignore").toFile();
+        assertEquals(expectedTfIgnore, tfIgnore);
+    }
+
+    private static Path createTempFileSystem(String... filesToCreate) throws IOException {
+        Path rootDirectory = Files.createTempDirectory("azuredevopstest");
+        for (String relativePath : filesToCreate) {
+            Path filePath = rootDirectory.resolve(relativePath);
+            Path directoryPath = filePath.getParent();
+
+            Files.createDirectories(directoryPath);
+            //noinspection ResultOfMethodCallIgnored
+            filePath.toFile().createNewFile();
+        }
+
+        return rootDirectory;
+    }
+}

--- a/plugin/test/com/microsoft/alm/plugin/versioncontrol/path/ServerPathTests.java
+++ b/plugin/test/com/microsoft/alm/plugin/versioncontrol/path/ServerPathTests.java
@@ -1,0 +1,16 @@
+package com.microsoft.alm.plugin.versioncontrol.path;
+
+import com.microsoft.alm.plugin.exceptions.ServerPathFormatException;
+import org.junit.Test;
+
+public class ServerPathTests {
+    @Test(expected = ServerPathFormatException.class)
+    public void testCanonicalizeWithDollarValidation() {
+        ServerPath.canonicalize("$/test/$path", true);
+    }
+
+    @Test
+    public void testCanonicalizeWithoutDollarValidation() {
+        ServerPath.canonicalize("$/test/$path", false); // should not throw
+    }
+}

--- a/plugin/test/com/microsoft/alm/plugin/versioncontrol/path/ServerPathTests.java
+++ b/plugin/test/com/microsoft/alm/plugin/versioncontrol/path/ServerPathTests.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
 package com.microsoft.alm.plugin.versioncontrol.path;
 
 import com.microsoft.alm.plugin.exceptions.ServerPathFormatException;


### PR DESCRIPTION
Closes #84.

We will now suggest the users to ignore the files whose names break the TF Everywhere client.

This PR will also add logging for the stack traces of asynchronous TFVC commands creation, because it makes debugging the command code significantly easy.