### PR TITLE
Guess authentication info for remotes without organization names

### DIFF
--- a/plugin/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
+++ b/plugin/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
@@ -28,6 +28,7 @@ ServerContextTable.RepoColumn=Repository
 Errors.AuthNotSuccessful=Authenticating to the server for Git repository ''{0}'' was not successful. Provide valid credentials and try again.
 Operation.Lookup.Canceled=Lookup operation was canceled by the user.
 Operation.Lookup.Errors=Unexpected errors were encountered while querying the server. The list shown may not be complete. Verify your server connection and retry.
+Plugin.AzureDevOps=Azure DevOps
 TFS.UnsupportedVersion=An error occurred while connecting to the server. The Azure DevOps plugin only supports TFS version 2015 or later. Verify your TFS server version and that the server URL you entered is correct.
 VSO.Auth.SessionExpired=Your previous Azure DevOps Services session has expired. Sign in again.
 VSO.Auth.Failed=Authentication failed for Azure DevOps Services. Sign out, verify your credentials, and sign in again.
@@ -372,6 +373,10 @@ Plugin.Error.GitExeNotConfigured=The Azure DevOps plugin requires Git settings t
 Plugin.Error.TFNotConfigured=The TF command line tool must be installed and the location identified in the Settings menu.
 Plugin.Error.TFNotConfiguredDialog.OpenSettings=Open Settings
 Plugin.Error.TFNotConfiguredDialog.Cancel=Cancel
+
+# Git
+Git.Notification.Remote=Unable to extract the Azure DevOps organization information from the Git remote URL. Please update the remote URL to include "organization@" before {0} host name.
+Git.Action.ConfigureRemotes=Manage Remotes...
 
 #TFVC
 Tfvc.Add.Scheduling=Scheduling addition...

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/resources/TfPluginBundle.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/resources/TfPluginBundle.java
@@ -48,6 +48,8 @@ public class TfPluginBundle {
 
     // Plugin general
     @NonNls
+    public static final String KEY_PLUGIN_AZURE_DEVOPS = "Plugin.AzureDevOps";
+    @NonNls
     public static final String KEY_TF_GIT = "Providers.TfGitCheckoutProvider";
     @NonNls
     public static final String KEY_GIT_NOT_CONFIGURED = "Plugin.Error.GitExeNotConfigured";
@@ -59,6 +61,12 @@ public class TfPluginBundle {
     public static final String KEY_TFVC_NOT_CONFIGURED_DIALOG_OPEN_SETTINGS = "Plugin.Error.TFNotConfiguredDialog.OpenSettings";
     @NonNls
     public static final String KEY_TFVC_NOT_CONFIGURED_DIALOG_CANCEL = "Plugin.Error.TFNotConfiguredDialog.Cancel";
+
+    // Git
+    @NonNls
+    public static final String KEY_GIT_NOTIFICATION_REMOTE = "Git.Notification.Remote";
+    @NonNls
+    public static final String KEY_GIT_CONFIGURE_REMOTES = "Git.Action.ConfigureRemotes";
 
     // Login form
     @NonNls

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/ui/common/AzureDevOpsNotifications.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/ui/common/AzureDevOpsNotifications.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
 package com.microsoft.alm.plugin.idea.common.ui.common;
 
 import com.intellij.notification.Notification;

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/ui/common/AzureDevOpsNotifications.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/ui/common/AzureDevOpsNotifications.java
@@ -1,0 +1,30 @@
+package com.microsoft.alm.plugin.idea.common.ui.common;
+
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationDisplayType;
+import com.intellij.notification.NotificationGroup;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.MessageType;
+import com.microsoft.alm.plugin.idea.common.resources.TfPluginBundle;
+import git4idea.remote.GitConfigureRemotesAction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class AzureDevOpsNotifications {
+    private static final NotificationGroup AZURE_DEVOPS_NOTIFICATIONS = new NotificationGroup(
+            TfPluginBundle.message(TfPluginBundle.KEY_PLUGIN_AZURE_DEVOPS),
+            NotificationDisplayType.BALLOON,
+            true);
+
+    public static void showManageRemoteUrlsNotification(@Nullable Project project, @NotNull String hostName) {
+        Notification notification = AZURE_DEVOPS_NOTIFICATIONS.createNotification(
+                TfPluginBundle.message(TfPluginBundle.KEY_GIT_NOTIFICATION_REMOTE, hostName),
+                MessageType.ERROR);
+        GitConfigureRemotesAction gitConfigureRemotesAction = new GitConfigureRemotesAction();
+        gitConfigureRemotesAction.getTemplatePresentation().setText(
+                TfPluginBundle.message(TfPluginBundle.KEY_GIT_CONFIGURE_REMOTES));
+        notification.addAction(gitConfigureRemotesAction);
+        Notifications.Bus.notify(notification, project);
+    }
+}

--- a/plugin/src/com/microsoft/alm/plugin/idea/git/extensions/TfGitHttpAuthDataProvider.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/extensions/TfGitHttpAuthDataProvider.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.alm.plugin.idea.git.extensions;
 
+import com.google.common.base.Strings;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.AuthData;
 import com.microsoft.alm.common.utils.UrlHelper;
@@ -10,14 +11,22 @@ import com.microsoft.alm.plugin.authentication.AuthHelper;
 import com.microsoft.alm.plugin.authentication.AuthenticationInfo;
 import com.microsoft.alm.plugin.authentication.VsoAuthenticationProvider;
 import com.microsoft.alm.plugin.context.ServerContextManager;
+import com.microsoft.alm.plugin.idea.common.ui.common.AzureDevOpsNotifications;
+import com.microsoft.alm.plugin.idea.git.utils.TfGitHelper;
 import git4idea.remote.GitHttpAuthDataProvider;
+import git4idea.repo.GitRemote;
 import org.apache.http.client.utils.URIBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class TfGitHttpAuthDataProvider implements GitHttpAuthDataProvider {
     private static final Logger logger = LoggerFactory.getLogger(TfGitHttpAuthDataProvider.class);
@@ -37,17 +46,89 @@ public class TfGitHttpAuthDataProvider implements GitHttpAuthDataProvider {
     @Nullable
     // @Override // HACK: It is impossible to mark this method as @Override according to the above.
     public AuthData getAuthData(@NotNull Project project, @NotNull String url, @NotNull String login) {
+        logger.info("getAuthData: processing URL {}, login {}", url, login);
         try {
-            String urlWithLogin = new URIBuilder(url).setUserInfo(login).build().toString();
-            return getAuthData(urlWithLogin);
+            String urlWithLogin = appendOrganizationInfo(url, login);
+            return getAuthData(project, urlWithLogin);
         } catch (URISyntaxException e) {
             logger.warn("Error when parsing URL \"" + url + "\"", e);
             return getAuthData(url);
         }
     }
 
+    @Nullable
+    // @Override // HACK: This method was introduced in IDEA 2018.2 thus we cannot mark it as an override without raising the IDEA version
+    public AuthData getAuthData(@NotNull Project project, @NotNull String url) {
+        logger.info("getAuthData: processing URL {}", url);
+
+        URI remoteUri = URI.create(url);
+        String host = remoteUri.getHost();
+        if (UrlHelper.isOrganizationHost(host)) {
+            logger.info("getAuthData: is Azure DevOps host: {}", host);
+
+            // For azure.com hosts (mainly for dev.azure.com), we need to check if the organization name could be
+            // determined from the URL passed from Git. Sometimes, when using the Git repositories created in Visual
+            // Studio, the organization name may be omitted from the authority part.
+            //
+            // Usually, a proper Git remote URL for dev.azure.com looks like this:
+            // https://{organization}@dev.azure.com/{organization}/{repo}/_git/{repo}
+            //
+            // The reason for that is simple: when authenticating the user, Git will only pass the authority part (i.e.
+            // https://{organization}@dev.azure.com) to the askpass program (and IDEA implements the askpass protocol
+            // for Git), so, without the "{organization}@" part in the URL authority, it would be impossible to know in
+            // which organization we should authenticate.
+            //
+            // If we're in the situation when we use dev.azure.com and the organization name is unknown from the
+            // authority part of the URL, we may guess the organization by analyzing the Git remotes in the current
+            // project.
+            if (!Strings.isNullOrEmpty(remoteUri.getUserInfo())) {
+                logger.info("getAuthData: URL has authentication info");
+                return getAuthDataForProcessedRemoteUrl(url);
+            }
+
+            Collection<GitRemote> remotes = TfGitHelper.getTfGitRemotes(project);
+            List<String> organizationsFromRemotes = remotes.stream()
+                    .map(GitRemote::getFirstUrl)
+                    .filter(Objects::nonNull)
+                    .map(URI::create)
+                    .filter(uri -> UrlHelper.isOrganizationHost(uri.getHost()))
+                    .map(UrlHelper::getAccountFromOrganizationUri)
+                    .filter(Objects::nonNull)
+                    .distinct()
+                    .collect(Collectors.toList());
+            if (organizationsFromRemotes.size() == 0) {
+                logger.info("getAuthData: no Azure DevOps organizations detected");
+                return null; // we cannot authenticate without knowing the organization
+            }
+
+            if (organizationsFromRemotes.size() > 1) {
+                // If there's more that one Azure-like Git remote, then we have no information on which remote to use,
+                // so we only could fail with notification.
+                logger.info("getAuthData: more than one Azure DevOps organizations detected: {}", organizationsFromRemotes);
+                AzureDevOpsNotifications.showManageRemoteUrlsNotification(project, host);
+                return null;
+            }
+
+            String organizationName = organizationsFromRemotes.get(0);
+
+            try {
+                url = appendOrganizationInfo(url, organizationName);
+            } catch (URISyntaxException e) {
+                logger.warn("Error when parsing URL \"" + url + "\"", e);
+            }
+
+            return getAuthData(url);
+        }
+
+        // Not an Azure DevOps URL; we have nothing to do.
+        logger.info("getAuthData: not an Azure DevOps URL: {}", url);
+        return null;
+    }
+
     @Override
     public AuthData getAuthData(@NotNull String url) {
+        logger.info("getAuthData: processing URL {}", url);
+
         url = UrlHelper.convertToCanonicalHttpApiBase(url);
 
         //try to find authentication info from saved server contexts
@@ -60,26 +141,49 @@ public class TfGitHttpAuthDataProvider implements GitHttpAuthDataProvider {
         logger.debug("getAuthData: Couldn't find authentication info from saved contexts.");
 
         if (UrlHelper.isTeamServicesUrl(url)) {
-            // We can't determine if the url is for a TFS on premise server but prompt for credentials if we know it is VSO
-            // IntelliJ calls us with a http server url e.g. http://myorganization.visualstudio.com
-            // convert to https:// for team services to avoid rest call failures
-            final String authUrl = UrlHelper.getHttpsUrlFromHttpUrl(url);
+            URI uri = URI.create(url);
+            String host = uri.getHost();
+            if (UrlHelper.isOrganizationHost(host)) {
+                // For dev.azure.com we need to check if the organization was included.
+                logger.info("getAuthData: is Azure DevOps host: {}", host);
+                if (Strings.isNullOrEmpty(UrlHelper.getAccountFromOrganizationUri(uri))) {
+                    logger.warn("getAuthData: no user information detected");
 
-            if (authUrl != null) {
-                final AuthenticationInfo vsoAuthenticationInfo = AuthHelper.getAuthenticationInfoSynchronously(VsoAuthenticationProvider.getInstance(), authUrl);
-                if (vsoAuthenticationInfo == null) {
-                    //user cancelled authentication, send empty credentials to cause a auth failure
-                    return new AuthData("", "");
-                } else {
-                    return new AuthData(vsoAuthenticationInfo.getUserName(), vsoAuthenticationInfo.getPassword());
+                    // If we're at this point, it could only mean that we're in IDEA version older than 2018.2, so we
+                    // have no Project and cannot determine the Git remotes in the project. Only thing we could do is
+                    // show a notification and suggest something's wrong with the remotes.
+                    AzureDevOpsNotifications.showManageRemoteUrlsNotification(null, host);
+                    return null;
                 }
-            } else {
-                logger.warn("getAuthData: Unable to get https Azure DevOps Services url for input url = " + url);
             }
+
+            return getAuthDataForProcessedRemoteUrl(url);
         }
 
         //Return null if we couldn't find matching git credentials
         //This will tell the Git plugin to prompt the user for credentials instead of failing silently with "Not authorized" error
+        return null;
+    }
+
+    @Nullable
+    private AuthData getAuthDataForProcessedRemoteUrl(String url) {
+        // We can't determine if the url is for a TFS on premise server but prompt for credentials if we know it is VSO
+        // IntelliJ calls us with a http server url e.g. http://myorganization.visualstudio.com
+        // convert to https:// for team services to avoid rest call failures
+        final String authUrl = UrlHelper.getHttpsUrlFromHttpUrl(url);
+
+        if (authUrl != null) {
+            final AuthenticationInfo vsoAuthenticationInfo = AuthHelper.getAuthenticationInfoSynchronously(VsoAuthenticationProvider.getInstance(), authUrl);
+            if (vsoAuthenticationInfo == null) {
+                //user cancelled authentication, send empty credentials to cause a auth failure
+                return new AuthData("", "");
+            } else {
+                return new AuthData(vsoAuthenticationInfo.getUserName(), vsoAuthenticationInfo.getPassword());
+            }
+        } else {
+            logger.warn("getAuthData: Unable to get https Azure DevOps Services url for input url = " + url);
+        }
+
         return null;
     }
 
@@ -102,5 +206,9 @@ public class TfGitHttpAuthDataProvider implements GitHttpAuthDataProvider {
             logger.warn("forgetPassword: If server is https:// user might see multiple prompts for entering password resulting in all failures.");
             ServerContextManager.getInstance().updateAuthenticationInfo(url);
         }
+    }
+
+    private static String appendOrganizationInfo(String url, String organization) throws URISyntaxException {
+        return new URIBuilder(url).setUserInfo(organization).build().toString();
     }
 }

--- a/plugin/src/com/microsoft/alm/plugin/idea/git/utils/TfGitHelper.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/utils/TfGitHelper.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class TfGitHelper {
     private static final String MASTER_BRANCH_PATTERN = "%s/master";
@@ -79,6 +80,12 @@ public class TfGitHelper {
             return true;
         }
         return false;
+    }
+
+    @NotNull
+    public static Collection<GitRemote> getTfGitRemotes(@NotNull Project project) {
+        List<GitRepository> repositories = GitUtil.getRepositoryManager(project).getRepositories();
+        return repositories.stream().flatMap(r -> getTfGitRemotes(r).stream()).collect(Collectors.toList());
     }
 
     public static Collection<GitRemote> getTfGitRemotes(@NotNull final GitRepository gitRepository) {

--- a/plugin/test/com/microsoft/alm/plugin/idea/git/extensions/TfGitHttpAuthDataProviderTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/git/extensions/TfGitHttpAuthDataProviderTest.java
@@ -7,6 +7,9 @@ import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.context.ServerContextManager;
 import com.microsoft.alm.plugin.idea.IdeaAbstractTest;
 import com.microsoft.alm.plugin.idea.common.settings.TeamServicesSecrets;
+import com.microsoft.alm.plugin.idea.common.ui.common.AzureDevOpsNotifications;
+import com.microsoft.alm.plugin.idea.git.utils.TfGitHelper;
+import git4idea.repo.GitRemote;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,15 +19,20 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.Arrays;
+import java.util.Collections;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({TeamServicesSecrets.class})
+@PrepareForTest({AzureDevOpsNotifications.class, GitRemote.class, TeamServicesSecrets.class, TfGitHelper.class})
 public class TfGitHttpAuthDataProviderTest extends IdeaAbstractTest {
     private final String SERVER_URL = "https://dev.azure.com/username";
     private final AuthenticationInfo authenticationInfo = new AuthenticationInfo(
@@ -32,12 +40,14 @@ public class TfGitHttpAuthDataProviderTest extends IdeaAbstractTest {
             "password",
             "serverUri",
             "userNameForDisplay");
+    private final Project project = Mockito.mock(Project.class);
+
 
     private TfGitHttpAuthDataProvider authDataProvider;
 
     @Before
     public void setUpTest() {
-        PowerMockito.mockStatic(TeamServicesSecrets.class);
+        PowerMockito.mockStatic(AzureDevOpsNotifications.class, TeamServicesSecrets.class, TfGitHelper.class);
 
         authDataProvider = new TfGitHttpAuthDataProvider();
         ServerContext context = Mockito.mock(ServerContext.class);
@@ -55,18 +65,14 @@ public class TfGitHttpAuthDataProviderTest extends IdeaAbstractTest {
     public void httpAuthShouldWorkOnUrlThatDoesNotRequireConversion() {
         AuthData authData = authDataProvider.getAuthData("https://dev.azure.com/username");
 
-        assertNotNull(authData);
-        assertEquals(authenticationInfo.getUserName(), authData.getLogin());
-        assertEquals(authenticationInfo.getPassword(), authData.getPassword());
+        assertAuthenticationInfoEquals(authenticationInfo, authData);
     }
 
     @Test
     public void httpAuthShouldConvertUrlProperly() {
         AuthData authData = authDataProvider.getAuthData("https://username@dev.azure.com/");
 
-        assertNotNull(authData);
-        assertEquals(authenticationInfo.getUserName(), authData.getLogin());
-        assertEquals(authenticationInfo.getPassword(), authData.getPassword());
+        assertAuthenticationInfoEquals(authenticationInfo, authData);
     }
 
     @Test
@@ -74,12 +80,88 @@ public class TfGitHttpAuthDataProviderTest extends IdeaAbstractTest {
         TfGitHttpAuthDataProvider mockedAuthDataProvider = Mockito.mock(TfGitHttpAuthDataProvider.class);
         when(mockedAuthDataProvider.getAuthData(any(Project.class), any(String.class), any(String.class))).thenCallRealMethod();
 
-        Project project = Mockito.mock(Project.class);
-
         mockedAuthDataProvider.getAuthData(project, "https://dev.azure.com", "username");
 
         verify(mockedAuthDataProvider, times(1)).getAuthData(
                 project,
                 "https://username@dev.azure.com");
+    }
+
+    @Test
+    public void testAuthDataWithValidRemoteUrl() {
+        AuthData result = authDataProvider.getAuthData(project, "https://username@dev.azure.com");
+
+        assertAuthenticationInfoEquals(authenticationInfo, result);
+    }
+
+    @Test
+    public void testAuthDataWithZeroRemotes() {
+        when(TfGitHelper.getTfGitRemotes(any(Project.class))).thenReturn(Collections.emptyList());
+        AuthData result = authDataProvider.getAuthData(project, "https://dev.azure.com");
+        assertNull(result);
+    }
+
+    @Test
+    public void testAuthDataWithOneRemote() {
+        GitRemote gitRemote = PowerMockito.mock(GitRemote.class);
+        when(gitRemote.getFirstUrl()).thenReturn("https://dev.azure.com/username/myproject/_git/myproject");
+        when(TfGitHelper.getTfGitRemotes(any(Project.class))).thenReturn(Collections.singleton(gitRemote));
+
+        AuthData result = authDataProvider.getAuthData(project, "https://dev.azure.com");
+
+        assertAuthenticationInfoEquals(authenticationInfo, result);
+    }
+
+    @Test
+    public void testAuthDataWithTwoRemotesSameOrganization() {
+        GitRemote gitRemote1 = Mockito.mock(GitRemote.class);
+        when(gitRemote1.getFirstUrl()).thenReturn("https://dev.azure.com/username/myproject1/_git/myproject1");
+
+        GitRemote gitRemote2 = Mockito.mock(GitRemote.class);
+        when(gitRemote2.getFirstUrl()).thenReturn("https://dev.azure.com/username/myproject2/_git/myproject2");
+
+        when(TfGitHelper.getTfGitRemotes(any(Project.class))).thenReturn(Arrays.asList(gitRemote1, gitRemote2));
+
+        AuthData result = authDataProvider.getAuthData(project, "https://dev.azure.com");
+
+        assertAuthenticationInfoEquals(authenticationInfo, result);
+    }
+
+    @Test
+    public void testAuthDataWithTwoRemotesDifferentOrganizations() {
+        GitRemote gitRemote1 = Mockito.mock(GitRemote.class);
+        when(gitRemote1.getFirstUrl()).thenReturn("https://dev.azure.com/username1/myproject1/_git/myproject1");
+
+        GitRemote gitRemote2 = Mockito.mock(GitRemote.class);
+        when(gitRemote2.getFirstUrl()).thenReturn("https://dev.azure.com/username2/myproject2/_git/myproject2");
+
+        when(TfGitHelper.getTfGitRemotes(any(Project.class))).thenReturn(Arrays.asList(gitRemote1, gitRemote2));
+
+        AuthData result = authDataProvider.getAuthData(project, "https://dev.azure.com");
+
+        assertNull(result);
+
+        verifyStatic();
+        AzureDevOpsNotifications.showManageRemoteUrlsNotification(
+                project,
+                "dev.azure.com");
+    }
+
+    @Test
+    public void testAuthDataWithNonDevAzureUrl() {
+        TfGitHttpAuthDataProvider mockedAuthDataProvider = Mockito.mock(TfGitHttpAuthDataProvider.class);
+        when(mockedAuthDataProvider.getAuthData(any(Project.class), any(String.class))).thenCallRealMethod();
+
+        mockedAuthDataProvider.getAuthData(project, "https://username.visualstudio.com");
+
+        verify(mockedAuthDataProvider, times(1))
+                .getAuthData("https://username.visualstudio.com");
+
+    }
+
+    private static void assertAuthenticationInfoEquals(AuthenticationInfo authenticationInfo, AuthData result) {
+        assertNotNull(result);
+        assertEquals(authenticationInfo.getUserName(), result.getLogin());
+        assertEquals(authenticationInfo.getPassword(), result.getPassword());
     }
 }

--- a/plugin/test/com/microsoft/alm/plugin/idea/git/extensions/TfGitHttpAuthDataProviderTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/git/extensions/TfGitHttpAuthDataProviderTest.java
@@ -78,6 +78,8 @@ public class TfGitHttpAuthDataProviderTest extends IdeaAbstractTest {
 
         mockedAuthDataProvider.getAuthData(project, "https://dev.azure.com", "username");
 
-        verify(mockedAuthDataProvider, times(1)).getAuthData("https://username@dev.azure.com");
+        verify(mockedAuthDataProvider, times(1)).getAuthData(
+                project,
+                "https://username@dev.azure.com");
     }
 }


### PR DESCRIPTION
Closes #205.

This PR introduces two distinct features. For context, see #205: currently we don't support authentication for Git remote URLs that don't have the `organization@` part before `dev.azure.com`. For example, `https://dev.azure.com/org/repo/_git/repo` isn't supported while `https://org@dev.azure.com/org/repo/_git/repo` is supported.

1. We'll try to **guess** the organization name based on the Git remote in current project. If project has multiple Git roots and/or multiple remotes, then all of them will be taken into account. If there's **exactly one** and the same Azure DevOps organization in all of these remotes, then it will be used as an authentication base.
2. If there's **more than one** different Azure DevOps organizations across all the Git remotes across the project, then we have no information about which of them we should authenticate against. So the only action we could take is to show the error message to the user, and suggest that the user will manually update the remotes.

As a side note, we'll now refuse to authenticate users if we don't know the organization name; this should reduce the confusion around our authentication mechanism, and should also allow the users to authenticate with manually tokens created in some cases.