### PR TITLE
Additional cases for #84

### DIFF
--- a/plugin/META-INF/plugin.xml
+++ b/plugin/META-INF/plugin.xml
@@ -92,6 +92,8 @@
         <applicationService serviceInterface="com.microsoft.alm.plugin.idea.common.settings.TeamServicesSettingsService"
                             serviceImplementation="com.microsoft.alm.plugin.idea.common.settings.TeamServicesSettingsService"/>
         <vcsConfigurableProvider implementation="com.microsoft.alm.plugin.idea.common.ui.settings.TeamServicesConfigurable"/>
+
+        <fileTypeFactory implementation="com.microsoft.alm.plugin.idea.tfvc.tfignore.TfIgnoreFileTypeFactory"/>
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij">

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
@@ -240,7 +240,7 @@ public abstract class Command<T> {
                     throw new ToolEulaNotAcceptedException(error);
                 }
                 if (error instanceof RuntimeException) {
-                    logger.error("Error: {}\nSync stack trace: {}", error, StringUtils.join(Thread.currentThread().getStackTrace(), "\n    at "));
+                    logger.warn("Error: {}\nSync stack trace: {}", error, StringUtils.join(Thread.currentThread().getStackTrace(), "\n    at "));
                     throw (RuntimeException) error;
                 } else {
                     // Wrap the exception

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/AddFileToTfIgnoreAction.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/AddFileToTfIgnoreAction.java
@@ -22,7 +22,7 @@ import java.io.File;
 import java.io.IOException;
 
 public class AddFileToTfIgnoreAction extends AnAction {
-    private static final Logger LOGGER = Logger.getInstance(AddFileToTfIgnoreAction.class);
+    private static final Logger ourLogger = Logger.getInstance(AddFileToTfIgnoreAction.class);
 
     @NotNull
     private final Project myProject;
@@ -38,16 +38,16 @@ public class AddFileToTfIgnoreAction extends AnAction {
 
     @Override
     public void actionPerformed(AnActionEvent e) {
-        LOGGER.info("Performing AddFileToTfIgnoreAction for " + myServerFilePath);
+        ourLogger.info("Performing AddFileToTfIgnoreAction for " + myServerFilePath);
 
         Workspace partialWorkspace = CommandUtils.getPartialWorkspace(myProject);
         String filePath = ObjectUtils.assertNotNull(
                 TfsFileUtil.translateServerItemToLocalItem(partialWorkspace.getMappings(), myServerFilePath, false));
         File localFile = new File(filePath);
-        LOGGER.info("Local file path: " + localFile.getAbsolutePath());
+        ourLogger.info("Local file path: " + localFile.getAbsolutePath());
 
         File tfIgnore = TfIgnoreUtil.findNearestOrRootTfIgnore(partialWorkspace.getMappings(), localFile);
-        LOGGER.info(".tfignore location: " + (tfIgnore == null ? "null" : tfIgnore.getAbsolutePath()));
+        ourLogger.info(".tfignore location: " + (tfIgnore == null ? "null" : tfIgnore.getAbsolutePath()));
 
         if (tfIgnore != null) {
             CommandProcessor.getInstance().executeCommand(
@@ -56,7 +56,7 @@ public class AddFileToTfIgnoreAction extends AnAction {
                         try {
                             TfIgnoreUtil.addToTfIgnore(this, tfIgnore, localFile);
                         } catch (IOException ex) {
-                            LOGGER.error(ex);
+                            ourLogger.error(ex);
                         }
                     }),
                     null,

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/AddFileToTfIgnoreAction.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/AddFileToTfIgnoreAction.java
@@ -38,12 +38,17 @@ public class AddFileToTfIgnoreAction extends AnAction {
 
     @Override
     public void actionPerformed(AnActionEvent e) {
+        LOGGER.info("Performing AddFileToTfIgnoreAction for " + myServerFilePath);
+
         Workspace partialWorkspace = CommandUtils.getPartialWorkspace(myProject);
         String filePath = ObjectUtils.assertNotNull(
                 TfsFileUtil.translateServerItemToLocalItem(partialWorkspace.getMappings(), myServerFilePath, false));
         File localFile = new File(filePath);
+        LOGGER.info("Local file path: " + localFile.getAbsolutePath());
 
         File tfIgnore = TfIgnoreUtil.findNearestOrRootTfIgnore(partialWorkspace.getMappings(), localFile);
+        LOGGER.info(".tfignore location: " + (tfIgnore == null ? "null" : tfIgnore.getAbsolutePath()));
+
         if (tfIgnore != null) {
             CommandProcessor.getInstance().executeCommand(
                     myProject,

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeProvider.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeProvider.java
@@ -45,7 +45,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Extends the VCS change provider to execture the correct events to find out the local changes in the workspace
@@ -101,7 +100,7 @@ public class TFSChangeProvider implements ChangeProvider {
             return;
         }
 
-        final List<String> pathsToProcess = TFVCUtil.filterValidTFVCPaths(myProject, roots).stream().map(FilePath::getPath).collect(Collectors.toList());
+        final List<String> pathsToProcess = TFVCUtil.filterValidTFVCPaths(myProject, roots);
         if (pathsToProcess.isEmpty()) {
             return;
         }

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeProvider.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeProvider.java
@@ -30,7 +30,6 @@ import com.intellij.openapi.vcs.changes.ChangelistBuilder;
 import com.intellij.openapi.vcs.changes.VcsDirtyScope;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.microsoft.alm.plugin.external.commands.ToolEulaNotAcceptedException;
-import com.microsoft.alm.plugin.external.exceptions.DollarInPathException;
 import com.microsoft.alm.plugin.external.models.PendingChange;
 import com.microsoft.alm.plugin.external.utils.CommandUtils;
 import com.microsoft.alm.plugin.idea.common.utils.IdeaHelper;
@@ -57,9 +56,10 @@ import java.util.List;
 public class TFSChangeProvider implements ChangeProvider {
     private static final Logger logger = LoggerFactory.getLogger(TFSChangeProvider.class);
 
+    @NotNull
     private final Project myProject;
 
-    public TFSChangeProvider(final Project project) {
+    public TFSChangeProvider(@NotNull final Project project) {
         myProject = project;
     }
 
@@ -107,11 +107,7 @@ public class TFSChangeProvider implements ChangeProvider {
 
         List<PendingChange> changes;
         try {
-            changes = CommandUtils.getStatusForFiles(null, pathsToProcess);
-        } catch (DollarInPathException e) {
-            logger.warn("'$' sign in file path detected: {}. Ignoring any files.", e.getServerFilePath());
-            TFVCNotifications.showInvalidDollarFilePathNotification(myProject, e.getServerFilePath());
-            return;
+            changes = CommandUtils.getStatusForFiles(myProject, null, pathsToProcess);
         } catch (final ToolEulaNotAcceptedException e) {
             logger.error("EULA not accepted");
             IdeaHelper.runOnUIThread(new Runnable() {

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeProvider.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeProvider.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Extends the VCS change provider to execture the correct events to find out the local changes in the workspace
@@ -100,7 +101,7 @@ public class TFSChangeProvider implements ChangeProvider {
             return;
         }
 
-        final List<String> pathsToProcess = TFVCUtil.filterValidTFVCPaths(myProject, roots);
+        final List<String> pathsToProcess = TFVCUtil.filterValidTFVCPaths(myProject, roots).stream().map(FilePath::getPath).collect(Collectors.toList());
         if (pathsToProcess.isEmpty()) {
             return;
         }

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileListener.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileListener.java
@@ -44,7 +44,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -205,16 +204,11 @@ public class TFSFileListener extends VcsVFSListener {
     }
 
     private void removeInvalidTFVCAddedFiles() {
-        Map<VirtualFile, FilePath> addedFiles = myAddedFiles.stream()
+        Map<VirtualFile, FilePath> addedFilePaths = myAddedFiles.stream()
                 .collect(Collectors.toMap(vf -> vf, vf -> new LocalFilePath(vf.getPath(), vf.isDirectory())));
-        Set<FilePath> validPaths = new HashSet<>(TFVCUtil.filterValidTFVCPaths(myProject, addedFiles.values()));
+        Set<FilePath> invalidPaths = TFVCUtil.collectInvalidTFVCPaths((TFSVcs) myVcs, addedFilePaths.values().stream())
+                .collect(Collectors.toSet());
 
-        for (Map.Entry<VirtualFile, FilePath> entry : addedFiles.entrySet()) {
-            VirtualFile file = entry.getKey();
-            FilePath path = entry.getValue();
-            if (!validPaths.contains(path)) {
-                myAddedFiles.remove(file);
-            }
-        }
+        myAddedFiles.removeIf(file -> invalidPaths.contains(addedFilePaths.get(file)));
     }
 }

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileListener.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileListener.java
@@ -75,7 +75,11 @@ public class TFSFileListener extends VcsVFSListener {
             ProgressManager.getInstance().runProcessWithProgressSynchronously(new Runnable() {
                 public void run() {
                     ProgressManager.getInstance().getProgressIndicator().setIndeterminate(true);
-                    pendingChanges.addAll(CommandUtils.getStatusForFiles(TFSVcs.getInstance(myProject).getServerContext(true), filePaths));
+                    pendingChanges.addAll(
+                            CommandUtils.getStatusForFiles(
+                                    myProject,
+                                    TFSVcs.getInstance(myProject).getServerContext(true),
+                                    filePaths));
                 }
             }, TfPluginBundle.message(TfPluginBundle.KEY_TFVC_ADD_SCHEDULING), false, myProject);
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListener.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListener.java
@@ -235,7 +235,19 @@ public class TFSFileSystemListener implements LocalFileOperationsHandler, Dispos
             return false;
         }
 
-        final Project currentProject = vcs.getProject();
+        boolean isDirectory = oldFile.isDirectory();
+        LocalFilePath oldFilePath = new LocalFilePath(oldFile.getPath(), isDirectory);
+        if (TFVCUtil.isInvalidTFVCPath(vcs, oldFilePath)) {
+            logger.warn("Invalid old TFVC path, ignore rename or move: {}", oldFilePath);
+            return false;
+        }
+
+        LocalFilePath newFilePath = new LocalFilePath(newPath, isDirectory);
+        if (TFVCUtil.isInvalidTFVCPath(vcs, newFilePath)) {
+            logger.warn("Invalid new TFVC path, ignore rename or move: {}", newFilePath);
+            return false;
+        }
+
         final String oldPath = oldFile.getPath();
         try {
             // a single file may have 0, 1, or 2 pending changes to it

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListener.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListener.java
@@ -68,7 +68,7 @@ public class TFSFileSystemListener implements LocalFileOperationsHandler, Dispos
         }
 
         if (TFVCUtil.isInvalidTFVCPath(vcs, new LocalFilePath(virtualFile.getPath(), virtualFile.isDirectory()))) {
-            logger.info("Invalid file name for TFVC, so not performing TFVC delete: {}", virtualFile.getPath());
+            logger.warn("Invalid file name for TFVC, so not performing TFVC delete: {}", virtualFile.getPath());
             return false;
         }
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSUpdateEnvironment.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSUpdateEnvironment.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class TFSUpdateEnvironment implements UpdateEnvironment {
     private static final Logger logger = LoggerFactory.getLogger(TFSUpdateEnvironment.class);
@@ -84,7 +85,7 @@ public class TFSUpdateEnvironment implements UpdateEnvironment {
                     break;
             }
 
-            List<String> filesUpdatePaths = TFVCUtil.filterValidTFVCPaths(project, Arrays.asList(contentRoots));
+            List<String> filesUpdatePaths = TFVCUtil.filterValidTFVCPaths(project, Arrays.asList(contentRoots)).stream().map(FilePath::getPath).collect(Collectors.toList());
             final SyncResults results = CommandUtils.syncWorkspace(tfsVcs.getServerContext(false), filesUpdatePaths, needRecursion, false);
 
             // add the changed files to updatedFiles so user knows what has occurred in the workspace

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSUpdateEnvironment.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSUpdateEnvironment.java
@@ -47,7 +47,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class TFSUpdateEnvironment implements UpdateEnvironment {
     private static final Logger logger = LoggerFactory.getLogger(TFSUpdateEnvironment.class);
@@ -85,7 +84,7 @@ public class TFSUpdateEnvironment implements UpdateEnvironment {
                     break;
             }
 
-            List<String> filesUpdatePaths = TFVCUtil.filterValidTFVCPaths(project, Arrays.asList(contentRoots)).stream().map(FilePath::getPath).collect(Collectors.toList());
+            List<String> filesUpdatePaths = TFVCUtil.filterValidTFVCPaths(project, Arrays.asList(contentRoots));
             final SyncResults results = CommandUtils.syncWorkspace(tfsVcs.getServerContext(false), filesUpdatePaths, needRecursion, false);
 
             // add the changed files to updatedFiles so user knows what has occurred in the workspace

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSVcs.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSVcs.java
@@ -123,7 +123,7 @@ public class TFSVcs extends AbstractVcs {
     public void activate() {
         fileListener = new TFSFileListener(getProject(), this);
         if (tfsFileSystemListener == null) {
-            tfsFileSystemListener = new TFSFileSystemListener();
+            tfsFileSystemListener = new TFSFileSystemListener(myProject);
         }
 
         checkCommandLineVersion();

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TFVCUtil.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TFVCUtil.java
@@ -70,9 +70,9 @@ public class TFVCUtil {
      * so we need to filter only the items belonging to a local workspace before passing arguments to these commands.
      */
     @NotNull
-    public static List<FilePath> filterValidTFVCPaths(@NotNull Project project, @NotNull Collection<FilePath> paths) {
+    public static List<String> filterValidTFVCPaths(@NotNull Project project, @NotNull Collection<FilePath> paths) {
         List<FilePath> mappingPaths = getMappingsFromWorkspace(project);
-        List<FilePath> filteredPaths = new ArrayList<>();
+        List<String> filteredPaths = new ArrayList<>();
         for (FilePath path : paths) {
             // if we get a change notification in the $tf folder, we need to just ignore it
             if (isInServiceDirectory(path)) {
@@ -84,7 +84,7 @@ public class TFVCUtil {
                 if (path.isUnder(mappingPath, false)) {
                     // Ignore any paths that has '$' in any component under the mapping root.
                     if (!hasIllegalDollarInAnyComponent(mappingPath, path)) {
-                        filteredPaths.add(path);
+                        filteredPaths.add(path.getPath());
                         break;
                     }
                 }

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TFVCUtil.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TFVCUtil.java
@@ -33,9 +33,9 @@ public class TFVCUtil {
      * so we need to filter only the items belonging to a local workspace before passing arguments to these commands.
      */
     @NotNull
-    public static List<String> filterValidTFVCPaths(@NotNull Project project, @NotNull Collection<FilePath> paths) {
+    public static List<FilePath> filterValidTFVCPaths(@NotNull Project project, @NotNull Collection<FilePath> paths) {
         List<FilePath> mappingPaths = getMappingsFromWorkspace(project);
-        List<String> pathsToProcess = new ArrayList<String>();
+        List<FilePath> filteredPaths = new ArrayList<>();
         for (FilePath path : paths) {
             // if we get a change notification in the $tf folder, we need to just ignore it
             if (StringUtils.containsIgnoreCase(path.getPath(), "$tf") ||
@@ -48,14 +48,14 @@ public class TFVCUtil {
                 if (path.isUnder(mappingPath, false)) {
                     // Ignore any paths that has '$' in any component under the mapping root.
                     if (!hasIllegalDollarInAnyComponent(mappingPath, path)) {
-                        pathsToProcess.add(path.getPath());
+                        filteredPaths.add(path);
                         break;
                     }
                 }
             }
         }
 
-        return pathsToProcess;
+        return filteredPaths;
     }
 
     private static List<FilePath> getMappingsFromWorkspace(@NotNull Project project) {

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TfIgnoreUtil.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TfIgnoreUtil.java
@@ -46,14 +46,19 @@ public class TfIgnoreUtil {
             if (file.isDirectory()) {
                 LocalFilePath filePath = new LocalFilePath(file.getAbsolutePath(), true);
                 if (localRoots.stream().noneMatch(root -> filePath.isUnder(root, false))) {
-                    // Path is not under any of the root mappings; return last potential tfignore location that was under
-                    // mapping.
+                    // Path is not under any of the root mappings; return last potential tfignore location that was
+                    // under mapping.
                     return potentialTfIgnore;
                 }
 
-                potentialTfIgnore = new File(FileUtil.join(file.getAbsolutePath(), TFIGNORE_FILE_NAME));
-                if (potentialTfIgnore.isFile()) {
-                    return potentialTfIgnore;
+                File tfIgnoreInCurrentDir = new File(FileUtil.join(file.getAbsolutePath(), TFIGNORE_FILE_NAME));
+                if (!tfIgnoreInCurrentDir.isDirectory()) {
+                    // Remember as a potential location for .tfignore if is not occupied by a directory.
+                    potentialTfIgnore = tfIgnoreInCurrentDir;
+                    if (potentialTfIgnore.isFile()) {
+                        // Return as a best match if already exists as a file.
+                        return potentialTfIgnore;
+                    }
                 }
             }
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TfIgnoreUtil.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TfIgnoreUtil.java
@@ -74,7 +74,7 @@ public class TfIgnoreUtil {
         String relativePath = FileUtil.getRelativePath(tfIgnore.getParentFile(), fileToIgnore);
         VirtualFile virtualTfIgnoreFile = LocalFileSystem.getInstance().findFileByIoFile(tfIgnore);
         if (virtualTfIgnoreFile == null) {
-            VirtualFile parentDir = ObjectUtils.assertNotNull(  // should never be null because of the way we work with .tfignore
+            VirtualFile parentDir = ObjectUtils.assertNotNull( // should never be null because of the way we work with .tfignore
                     LocalFileSystem.getInstance().findFileByIoFile(tfIgnore.getParentFile()));
             virtualTfIgnoreFile = parentDir.createChildData(requestor, TFIGNORE_FILE_NAME);
         }

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/operations/RenameFileDirectory.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/operations/RenameFileDirectory.java
@@ -76,9 +76,12 @@ public class RenameFileDirectory {
             // 0 - file has not been touched in the local workspace
             // 1 - file has versioned OR unversioned changes
             // 2 - file has versioned AND unversioned changes (rare but can happen)
-            final List<PendingChange> pendingChanges = new ArrayList<PendingChange>(2);
-            pendingChanges.addAll(CommandUtils.getStatusForFiles(TFSVcs.getInstance(project).getServerContext(true),
-                    ImmutableList.of(currentPath)));
+            final List<PendingChange> pendingChanges = new ArrayList<>(2);
+            pendingChanges.addAll(
+                    CommandUtils.getStatusForFiles(
+                            project,
+                            TFSVcs.getInstance(project).getServerContext(true),
+                            ImmutableList.of(currentPath)));
 
             // ** Rename logic **
             // If 1 change and it's an add that means it's a new unversioned file so rename thru the file system

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/operations/ScheduleForDeletion.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/operations/ScheduleForDeletion.java
@@ -69,7 +69,7 @@ public class ScheduleForDeletion {
             final ServerContext context = TFSVcs.getInstance(project).getServerContext(true);
 
             for (final String path : filePaths) {
-                final List<PendingChange> fileChanges = CommandUtils.getStatusForFiles(context, ImmutableList.of(path));
+                final List<PendingChange> fileChanges = CommandUtils.getStatusForFiles(project, context, ImmutableList.of(path));
 
                 // deleting a file that has no changes
                 if (fileChanges.isEmpty()) {

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/tfignore/TfIgnoreFileType.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/tfignore/TfIgnoreFileType.java
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.alm.plugin.idea.tfvc.tfignore;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.fileTypes.LanguageFileType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class TfIgnoreFileType extends LanguageFileType {
+
+    TfIgnoreFileType() {
+        super(TfIgnoreLanguage.INSTANCE);
+    }
+
+    @NotNull
+    @Override
+    public String getName() {
+        return ".tfignore";
+    }
+
+    @NotNull
+    @Override
+    public String getDescription() {
+        return "Ignore file for TFVC";
+    }
+
+    @NotNull
+    @Override
+    public String getDefaultExtension() {
+        return "tfignore";
+    }
+
+    @Nullable
+    @Override
+    public Icon getIcon() {
+        return AllIcons.FileTypes.Text;
+    }
+}

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/tfignore/TfIgnoreFileTypeFactory.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/tfignore/TfIgnoreFileTypeFactory.java
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.alm.plugin.idea.tfvc.tfignore;
+
+import com.intellij.openapi.fileTypes.FileTypeConsumer;
+import com.intellij.openapi.fileTypes.FileTypeFactory;
+import org.jetbrains.annotations.NotNull;
+
+public class TfIgnoreFileTypeFactory extends FileTypeFactory {
+
+    @Override
+    public void createFileTypes(@NotNull FileTypeConsumer consumer) {
+        consumer.consume(new TfIgnoreFileType());
+    }
+}

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/tfignore/TfIgnoreLanguage.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/tfignore/TfIgnoreLanguage.java
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.alm.plugin.idea.tfvc.tfignore;
+
+import com.intellij.lang.Language;
+
+public class TfIgnoreLanguage extends Language { // TODO: Inherit from IgnoreLanguage if we target IDEA 2019.*
+    public static TfIgnoreLanguage INSTANCE = new TfIgnoreLanguage();
+    private TfIgnoreLanguage() {
+        super("TFIgnore");
+    }
+}

--- a/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListenerTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListenerTest.java
@@ -105,7 +105,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
         when(mockPendingChange.getLocalItem()).thenReturn(CURRENT_FILE_PATH);
         when(mockPendingChange.getVersion()).thenReturn("5");
 
-        tfsFileSystemListener = new TFSFileSystemListener();
+        tfsFileSystemListener = new TFSFileSystemListener(mockProject);
     }
 
     @Test
@@ -121,7 +121,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
 
     @Test
     public void testRename_FileNoChanges() throws Exception {
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(Collections.EMPTY_LIST);
 
         boolean result = tfsFileSystemListener.rename(mockVirtualFile, NEW_FILE_NAME);
@@ -134,7 +134,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     @Test
     public void testRename_FileEditChanges() throws Exception {
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.EDIT));
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         boolean result = tfsFileSystemListener.rename(mockVirtualFile, NEW_FILE_NAME);
@@ -147,7 +147,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     @Test
     public void testRename_FileEditRenameChanges() throws Exception {
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.EDIT, ServerStatusType.RENAME));
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         boolean result = tfsFileSystemListener.rename(mockVirtualFile, NEW_FILE_NAME);
@@ -161,7 +161,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     public void testRename_FileUnversionedChange() throws Exception {
         when(mockPendingChange.isCandidate()).thenReturn(true);
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.ADD));
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         boolean result = tfsFileSystemListener.rename(mockVirtualFile, NEW_FILE_NAME);
@@ -175,7 +175,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     public void testRename_FileAdd() throws Exception {
         when(mockPendingChange.isCandidate()).thenReturn(false);
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.ADD));
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         boolean result = tfsFileSystemListener.rename(mockVirtualFile, NEW_FILE_NAME);
@@ -187,7 +187,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
 
     @Test
     public void testMove_FileNoChanges() throws Exception {
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(Collections.EMPTY_LIST);
 
         boolean result = tfsFileSystemListener.move(mockVirtualFile, mockNewDirectory);
@@ -200,7 +200,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     @Test
     public void testMove_FileEditChanges() throws Exception {
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.EDIT));
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         boolean result = tfsFileSystemListener.move(mockVirtualFile, mockNewDirectory);
@@ -213,7 +213,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     @Test
     public void testMove_FileEditRenameChanges() throws Exception {
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.EDIT, ServerStatusType.RENAME));
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         boolean result = tfsFileSystemListener.move(mockVirtualFile, mockNewDirectory);
@@ -227,7 +227,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     public void testMove_FileUnversionedChange() throws Exception {
         when(mockPendingChange.isCandidate()).thenReturn(true);
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.ADD));
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         boolean result = tfsFileSystemListener.move(mockVirtualFile, mockNewDirectory);
@@ -241,7 +241,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     public void testMove_FileAdd() throws Exception {
         when(mockPendingChange.isCandidate()).thenReturn(false);
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.ADD));
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         boolean result = tfsFileSystemListener.move(mockVirtualFile, mockNewDirectory);
@@ -277,7 +277,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
 
     @Test
     public void testDelete_NoChanges() throws Exception {
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(Collections.EMPTY_LIST);
 
         boolean result = tfsFileSystemListener.delete(mockVirtualFile);
@@ -290,7 +290,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     public void testDelete_FileUnversionedAdd() throws Exception {
         when(mockPendingChange.isCandidate()).thenReturn(true);
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.ADD));
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         boolean result = tfsFileSystemListener.delete(mockVirtualFile);
@@ -305,7 +305,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     public void testDelete_FileUnversionedDelete() throws Exception {
         when(mockPendingChange.isCandidate()).thenReturn(true);
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.DELETE));
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         boolean result = tfsFileSystemListener.delete(mockVirtualFile);
@@ -319,7 +319,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     public void testDelete_FileAdd() throws Exception {
         when(mockPendingChange.isCandidate()).thenReturn(false);
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.ADD));
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         boolean result = tfsFileSystemListener.delete(mockVirtualFile);
@@ -334,7 +334,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     public void testDelete_FileDelete() throws Exception {
         when(mockPendingChange.isCandidate()).thenReturn(false);
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.DELETE));
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         boolean result = tfsFileSystemListener.delete(mockVirtualFile);
@@ -349,7 +349,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     public void testDelete_FileEdit() throws Exception {
         when(mockPendingChange.isCandidate()).thenReturn(false);
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.EDIT));
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         boolean result = tfsFileSystemListener.delete(mockVirtualFile);
@@ -364,7 +364,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
         when(mockPendingChange.getSourceItem()).thenReturn("$/server/path/to/file.txt");
         when(mockPendingChange.isCandidate()).thenReturn(false);
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.RENAME));
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         boolean result = tfsFileSystemListener.delete(mockVirtualFile);
@@ -377,7 +377,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     public void testDelete_FileLock() throws Exception {
         when(mockPendingChange.isCandidate()).thenReturn(true);
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.LOCK));
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         boolean result = tfsFileSystemListener.delete(mockVirtualFile);
@@ -393,7 +393,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
         when(mockPendingChange.getSourceItem()).thenReturn("$/server/path/to/file.txt");
         when(mockPendingChange.isCandidate()).thenReturn(false);
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.EDIT, ServerStatusType.RENAME));
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         boolean result = tfsFileSystemListener.delete(mockVirtualFile);
@@ -407,7 +407,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     public void testDelete_FileUndeleted() throws Exception {
         when(mockPendingChange.isCandidate()).thenReturn(false);
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.UNDELETE));
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         boolean result = tfsFileSystemListener.delete(mockVirtualFile);

--- a/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListenerTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListenerTest.java
@@ -16,6 +16,7 @@ import com.microsoft.alm.plugin.external.models.ServerStatusType;
 import com.microsoft.alm.plugin.external.utils.CommandUtils;
 import com.microsoft.alm.plugin.idea.IdeaAbstractTest;
 import com.microsoft.alm.plugin.idea.common.utils.VcsHelper;
+import com.microsoft.alm.plugin.idea.tfvc.core.tfs.TFVCUtil;
 import com.microsoft.alm.plugin.idea.tfvc.core.tfs.VersionControlPath;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,7 +44,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({CommandUtils.class, TFSVcs.class, LocalFileSystem.class, VersionControlPath.class, VcsHelper.class})
+@PrepareForTest({CommandUtils.class, TFSVcs.class, TFVCUtil.class, LocalFileSystem.class, VersionControlPath.class, VcsHelper.class})
 public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     private String CURRENT_FILE_NAME = "file.txt";
     private String NEW_FILE_NAME = "newName.txt";
@@ -85,7 +86,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        PowerMockito.mockStatic(CommandUtils.class, TFSVcs.class, LocalFileSystem.class, VersionControlPath.class, VcsHelper.class);
+        PowerMockito.mockStatic(CommandUtils.class, TFSVcs.class, TFVCUtil.class, LocalFileSystem.class, VersionControlPath.class, VcsHelper.class);
 
         when(mockTFSVcs.getProject()).thenReturn(mockProject);
         when(mockVcsShowConfirmationOption.getValue()).thenReturn(VcsShowConfirmationOption.Value.DO_ACTION_SILENTLY);
@@ -99,6 +100,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
         when(mockNewDirectory.getPath()).thenReturn(NEW_DIRECTORY_PATH);
         when(mockTFSVcs.getServerContext(anyBoolean())).thenReturn(mockServerContext);
         when(TFSVcs.getInstance(mockProject)).thenReturn(mockTFSVcs);
+        when(TFVCUtil.isInvalidTFVCPath(eq(mockTFSVcs), any(FilePath.class))).thenReturn(false);
 
         FilePath mockFilePath = mock(FilePath.class);
         when(VersionControlPath.getFilePath(CURRENT_FILE_PATH, false)).thenReturn(mockFilePath);

--- a/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/tfs/operations/RenameFileDirectoryTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/tfs/operations/RenameFileDirectoryTest.java
@@ -110,7 +110,7 @@ public class RenameFileDirectoryTest extends IdeaAbstractTest {
     @Test
     public void testExecute_RenameFileNoChanges() {
         when(mockVirtualFile.getPath()).thenReturn(CURRENT_FILE_PATH);
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(any(Project.class), eq(mockServerContext), eq(ImmutableList.of(CURRENT_FILE_PATH))))
                 .thenReturn(Collections.EMPTY_LIST);
 
         RenameFileDirectory.execute(mockPsiFile, NEW_FILE_NAME, usageInfos, mockListener);
@@ -128,7 +128,7 @@ public class RenameFileDirectoryTest extends IdeaAbstractTest {
     public void testExecute_RenameDirectoryNoChanges() {
         String dirName = Path.combine("/path/to/the", "directory");
         when(mockVirtualFile.getPath()).thenReturn(dirName);
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(dirName)))
+        when(CommandUtils.getStatusForFiles(any(Project.class), eq(mockServerContext), eq(ImmutableList.of(dirName))))
                 .thenReturn(Collections.EMPTY_LIST);
 
         RenameFileDirectory.execute(mockPsiFile, NEW_DIRECTORY_NAME, usageInfos, mockListener);
@@ -146,7 +146,7 @@ public class RenameFileDirectoryTest extends IdeaAbstractTest {
     public void testExecute_RenameFileEditChanges() {
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.EDIT));
         when(mockVirtualFile.getPath()).thenReturn(CURRENT_FILE_PATH);
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(any(Project.class), eq(mockServerContext), eq(ImmutableList.of(CURRENT_FILE_PATH))))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         RenameFileDirectory.execute(mockPsiFile, NEW_FILE_NAME, usageInfos, mockListener);
@@ -164,7 +164,7 @@ public class RenameFileDirectoryTest extends IdeaAbstractTest {
     public void testExecute_RenameFileEditRenameChanges() {
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.EDIT, ServerStatusType.RENAME));
         when(mockVirtualFile.getPath()).thenReturn(CURRENT_FILE_PATH);
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(any(Project.class), eq(mockServerContext), eq(ImmutableList.of(CURRENT_FILE_PATH))))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         RenameFileDirectory.execute(mockPsiFile, NEW_FILE_NAME, usageInfos, mockListener);
@@ -182,7 +182,7 @@ public class RenameFileDirectoryTest extends IdeaAbstractTest {
     public void testExecute_RenameFileUnversionedChange() {
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.ADD));
         when(mockVirtualFile.getPath()).thenReturn(CURRENT_FILE_PATH);
-        when(CommandUtils.getStatusForFiles(mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
+        when(CommandUtils.getStatusForFiles(any(Project.class), eq(mockServerContext), eq(ImmutableList.of(CURRENT_FILE_PATH))))
                 .thenReturn(ImmutableList.of(mockPendingChange));
 
         RenameFileDirectory.execute(mockPsiFile, NEW_FILE_NAME, usageInfos, mockListener);


### PR DESCRIPTION
This fixes a bunch of exceptions that were caught by our internal testing for various scenarios:
- file delete
- file move
- file add

when the path of the file contains dollar character.

This PR also introduces the language and the file type for `.tfignore`, because otherwise the IDEA API isn't able to perform `getDocument` for this file (to perform textual file modifications).