### PR TITLE
Set version in plugin.xml from gradle.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,13 +90,15 @@ project(":plugin") {
         version = idea_version
         plugins = ['git4idea']
         pluginName = 'com.microsoft.vso.idea'
+        updateSinceUntilBuild = false
+    }
+
+    patchPluginXml {
+        pluginXmlFiles = ['META-INF/plugin.xml']
     }
 
     jar {
         baseName 'com.microsoft.alm.plugin.idea'
-        from('.') {
-            include 'META-INF/plugin.xml'
-        }
     }
 
     task showVersion() {

--- a/plugin/META-INF/plugin.xml
+++ b/plugin/META-INF/plugin.xml
@@ -6,7 +6,7 @@
 <idea-plugin version="2">
     <id>com.microsoft.vso.idea</id>
     <name>Azure DevOps</name>
-    <version>1.155.0</version>
+    <!-- <version>1.155.0</version> NOTE: Version is set automatically on build, update it in gradle.properties -->
     <category>VCS Integration</category>
     <vendor url="https://azure.microsoft.com/en-us/services/devops/">Microsoft Corporation</vendor>
     <description><![CDATA[
@@ -57,7 +57,6 @@
     ]]></description>
 
     <change-notes><![CDATA[
-      <b>v 1.154.0</b>
       <br />
       <ul>
         <li>Support for authentication in repositories shared with Visual Studio (<a href="https://github.com/microsoft/azure-devops-intellij/pull/205">#205</a>)</li>


### PR DESCRIPTION
After this PR, the only source of version number will be `gradle.properties`.  This number will be used as a version for both `*.jar` and patched `plugin.xml`.

And we'll just drop the version number from the release notes to not copy-paste it :)