### PR TITLE
Improve error message when parsing account lookup response

### DIFF
--- a/plugin/src/com/microsoft/alm/plugin/operations/AccountLookupOperation.java
+++ b/plugin/src/com/microsoft/alm/plugin/operations/AccountLookupOperation.java
@@ -15,10 +15,12 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -85,6 +87,14 @@ public class AccountLookupOperation extends Operation {
             onLookupResults(results);
             onLookupCompleted();
         } catch (Throwable ex) {
+            if (ex instanceof WebApplicationException) {
+                WebApplicationException webEx = (WebApplicationException)ex;
+                Response response = webEx.getResponse();
+                if (response != null) {
+                    logger.warn("Error response content: {}", response.readEntity(String.class));
+                }
+            }
+
             if (AuthHelper.isNotAuthorizedError(ex)) {
                 final ServerContext context = ServerContextManager.getInstance().updateAuthenticationInfo(VsoAuthenticationProvider.VSO_AUTH_URL);
                 if (context == null) {

--- a/plugin/src/com/microsoft/alm/plugin/operations/AccountLookupOperation.java
+++ b/plugin/src/com/microsoft/alm/plugin/operations/AccountLookupOperation.java
@@ -141,7 +141,7 @@ public class AccountLookupOperation extends Operation {
         try {
             rootNode = objectMapper.readTree(response);
         } catch (IOException e) {
-            logger.error("Could not parse Account response", e);
+            logger.error("Could not parse Account response:\n" + response, e);
             throw new TeamServicesException(TeamServicesException.KEY_VSO_AUTH_FAILED, e);
         }
 


### PR DESCRIPTION
Sometimes the server could say something like "HTTP Error 400. The size of the request headers is too long."

This is actually useful information we should preserve in the logs.