### PR TITLE
Update the CI to use new Pipeline Artifacts

### DIFF
--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -12,20 +12,16 @@ steps:
     testResultsFiles: '**/TEST-*.xml'
     jdkVersionOption: 1.8
 
-- task: CopyPublishBuildArtifacts@1
+- task: PublishPipelineArtifact@1
   displayName: "Publish Artifact: $(build.buildNumber)"
   condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false))
   inputs:
-    CopyRoot: 'plugin/build/distributions'
-    Contents: '*.zip'
-    ArtifactName: '$(build.buildNumber)'
-    ArtifactType: Container
+    path: 'plugin/build/distributions'
+    artifact: '$(build.buildNumber)'
 
-- task: CopyPublishBuildArtifacts@1
+- task: PublishPipelineArtifact@1
   displayName: "Publish Artifact: $(build.buildNumber)-reports"
   condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false))
   inputs:
-    CopyRoot: 'plugin/build/reports'
-    Contents: '*'
-    ArtifactName: '$(build.buildNumber)-reports'
-    ArtifactType: Container
+    path: 'plugin/build/reports'
+    artifact: '$(build.buildNumber)-reports'


### PR DESCRIPTION
The `CopyPublishBuildArtifacts@1` task we use was deprecated in the Azure Pipelines. This PR migrates our pipeline build to use a newer (and presumably better) task, `PublishPipelineArtifact@1`.