### PR TITLE
Add a parallel build for IDEA 2019.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,12 +173,6 @@ subprojects {
     }
 
     /**
-     * Preparing for release build
-     */
-    task prepRelease() {
-    }
-
-    /**
      * Open source prep
      */
     checkstyle {

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ project(":plugin") {
     version buildNumber
 
     intellij {
-        version = idea_version
+        version = ideaVersion
         plugins = ['git4idea']
         pluginName = 'com.microsoft.vso.idea'
         updateSinceUntilBuild = false
@@ -103,6 +103,7 @@ project(":plugin") {
 
     task showVersion() {
         println("version = " + buildNumber)
+        println("ideaVersion = " + ideaVersion)
     }
 
     task zip(dependsOn: ['buildPlugin','test']) {}
@@ -112,7 +113,7 @@ project(":L2Tests") {
     apply plugin: 'org.jetbrains.intellij'
 
     intellij {
-        version = idea_version
+        version = ideaVersion
         plugins = ['git4idea']
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 buildNumber=1.156.0
-idea_version=2017.2
+ideaVersion=2017.2

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/ToolEulaNotAcceptedException.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/ToolEulaNotAcceptedException.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
 package com.microsoft.alm.plugin.external.commands;
 
 public class ToolEulaNotAcceptedException extends RuntimeException {

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/services/IdeaCertificateService.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/services/IdeaCertificateService.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
 package com.microsoft.alm.plugin.idea.common.services;
 
 import com.intellij.util.net.ssl.CertificateManager;

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/settings/TeamServicesSettingsService.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/settings/TeamServicesSettingsService.java
@@ -8,7 +8,6 @@ import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
-import com.intellij.openapi.components.StoragePathMacros;
 import com.microsoft.alm.plugin.authentication.AuthenticationInfo;
 import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.context.ServerContextManager;
@@ -28,8 +27,7 @@ import java.util.Map;
  */
 @State(
         name = "VSTSSettings",
-        storages = {@Storage(
-                file = StoragePathMacros.APP_CONFIG + "/vsts_settings.xml")}
+        storages = {@Storage("vsts_settings.xml")}
 )
 public class TeamServicesSettingsService implements PersistentStateComponent<SettingsState> {
     private static final Logger logger = LoggerFactory.getLogger(TeamServicesSettingsService.class);

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSCommittedChangesProvider.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSCommittedChangesProvider.java
@@ -123,10 +123,14 @@ public class TFSCommittedChangesProvider implements CachingCommittedChangesProvi
         return true;
     }
 
+    @SuppressWarnings("unchecked") // TODO: We have to use the raw type for the AsynchConsumer here, because the
+                                   // signature in question was changed in IDEA 2019.2. We may use the proper type here
+                                   // only after migration to 2019.2+.
+    @Override
     public void loadCommittedChanges(final ChangeBrowserSettings settings,
                                      final RepositoryLocation location,
                                      final int maxCount,
-                                     final AsynchConsumer<CommittedChangeList> consumer) throws VcsException {
+                                     final AsynchConsumer consumer) throws VcsException {
         // TODO: (Jetbrains) if revision and date filters are both set, which one should have priority?
         VersionSpec versionFrom = VersionSpec.create(1);
         if (settings.getChangeAfterFilter() != null) {

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TFVCUtil.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TFVCUtil.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
 package com.microsoft.alm.plugin.idea.tfvc.core.tfs;
 
 import com.intellij.openapi.project.Project;

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TfIgnoreUtil.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TfIgnoreUtil.java
@@ -10,7 +10,6 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vcs.LocalFilePath;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.openapi.vfs.VirtualFileEvent;
 import com.intellij.util.ObjectUtils;
 import com.microsoft.alm.plugin.external.models.Workspace;
 import org.jetbrains.annotations.NotNull;
@@ -71,8 +70,10 @@ public class TfIgnoreUtil {
 
     /**
      * Adds an item into the .tfignore file.
-     * @param requestor an object that requested the change; see {@link VirtualFileEvent#getRequestor}
-     * @param tfIgnore a {@link File} object representing the .tfignore file
+     *
+     * @param requestor    an object that requested the change; see
+     *                     {@link com.intellij.openapi.vfs.VirtualFileEvent#getRequestor}
+     * @param tfIgnore     a {@link File} object representing the .tfignore file
      * @param fileToIgnore a file to ignore
      */
     public static void addToTfIgnore(@NotNull Object requestor, @NotNull File tfIgnore, @NotNull File fileToIgnore) throws IOException {

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/tfignore/TfIgnoreFileType.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/tfignore/TfIgnoreFileType.java
@@ -8,7 +8,7 @@ import com.intellij.openapi.fileTypes.LanguageFileType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.*;
+import javax.swing.Icon;
 
 public class TfIgnoreFileType extends LanguageFileType {
 

--- a/plugin/src/com/microsoft/alm/plugin/services/CertificateService.java
+++ b/plugin/src/com/microsoft/alm/plugin/services/CertificateService.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
 package com.microsoft.alm.plugin.services;
 
 import javax.net.ssl.SSLContext;

--- a/plugin/test/com/microsoft/alm/plugin/idea/git/extensions/TfGitHttpAuthDataProviderTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/git/extensions/TfGitHttpAuthDataProviderTest.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
 package com.microsoft.alm.plugin.idea.git.extensions;
 
 import com.intellij.openapi.project.Project;

--- a/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/tfs/StatusProviderTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/tfs/StatusProviderTest.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
 package com.microsoft.alm.plugin.idea.tfvc.core.tfs;
 
 import com.intellij.openapi.vcs.FilePath;

--- a/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TFVCUtilTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TFVCUtilTest.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
 package com.microsoft.alm.plugin.idea.tfvc.core.tfs;
 
 import com.google.common.collect.Iterables;

--- a/plugin/test/com/microsoft/alm/plugin/mocks/MockCertificateService.java
+++ b/plugin/test/com/microsoft/alm/plugin/mocks/MockCertificateService.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
 package com.microsoft.alm.plugin.mocks;
 
 import com.microsoft.alm.plugin.services.CertificateService;

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -1,27 +1,44 @@
-steps:
-- task: CmdLine@1
-  displayName: Run printenv
-  inputs:
-    filename: printenv
+jobs:
+  - job: production_build_2017_2
+    steps:
+      - task: CmdLine@1
+        displayName: Run printenv
+        inputs:
+          filename: printenv
 
-- task: Gradle@1
-  displayName: Gradle build (zip)
-  inputs:
-    options: '--info --scan'
-    tasks: clean :plugin:prepRelease zip
-    testResultsFiles: '**/TEST-*.xml'
-    jdkVersionOption: 1.8
+      - task: Gradle@1
+        displayName: Gradle build (zip)
+        inputs:
+          options: '--info --scan'
+          tasks: clean :plugin:prepRelease zip
+          testResultsFiles: '**/TEST-*.xml'
+          jdkVersionOption: 1.8
 
-- task: PublishPipelineArtifact@1
-  displayName: "Publish Artifact: $(build.buildNumber)"
-  condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false))
-  inputs:
-    path: 'plugin/build/distributions'
-    artifact: '$(build.buildNumber)'
+      - task: PublishPipelineArtifact@1
+        displayName: "Publish Artifact: $(build.buildNumber)"
+        condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false))
+        inputs:
+          path: 'plugin/build/distributions'
+          artifact: '$(build.buildNumber)'
 
-- task: PublishPipelineArtifact@1
-  displayName: "Publish Artifact: $(build.buildNumber)-reports"
-  condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false))
-  inputs:
-    path: 'plugin/build/reports'
-    artifact: '$(build.buildNumber)-reports'
+      - task: PublishPipelineArtifact@1
+        displayName: "Publish Artifact: $(build.buildNumber)-reports"
+        condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false))
+        inputs:
+          path: 'plugin/build/reports'
+          artifact: '$(build.buildNumber)-reports'
+
+  - job: test_build_2019_2
+    steps:
+      - task: CmdLine@1
+        displayName: Run printenv
+        inputs:
+          filename: printenv
+
+      - task: Gradle@1
+        displayName: Gradle build (zip)
+        inputs:
+          options: '--info --scan -PideaVersion=2019.2'
+          tasks: clean :plugin:prepRelease zip
+          testResultsFiles: '**/TEST-*.xml'
+          jdkVersionOption: 1.8

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -10,7 +10,7 @@ jobs:
         displayName: Gradle build (zip)
         inputs:
           options: '--info --scan'
-          tasks: clean :plugin:prepRelease zip
+          tasks: clean build zip
           testResultsFiles: '**/TEST-*.xml'
           jdkVersionOption: 1.8
 
@@ -39,6 +39,6 @@ jobs:
         displayName: Gradle build (zip)
         inputs:
           options: '--info --scan -PideaVersion=2019.2'
-          tasks: clean :plugin:prepRelease zip
+          tasks: clean :plugin:build
           testResultsFiles: '**/TEST-*.xml'
           jdkVersionOption: 1.8

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -39,6 +39,6 @@ jobs:
         displayName: Gradle build (zip)
         inputs:
           options: '--info --scan -PideaVersion=2019.2'
-          tasks: clean :plugin:build
+          tasks: clean :plugin:compileJava
           testResultsFiles: '**/TEST-*.xml'
           jdkVersionOption: 1.8


### PR DESCRIPTION
This will help us to build both with IDEA 2017.2 and IDEA 2019.2 (to make sure the plugin is compatible with the latest stable IDEA release).

More changes will come later to change the compatibility policy to a more strict one.

We'll also run all the enabled inspections (findBugs && checkStyle) on CI. I've fixed all the critical issues that were reported by these tools.