### PR TITLE
New IntelliJ version support policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a plugin for working with Git and TFVC repositories on Azure DevOps and Team Foundation Server (TFS) 2015+ inside IntelliJ, Android Studio, 
 and various other JetBrains IDEs. It is supported on Linux, Mac OS X, and Windows.
-It is compatible with IntelliJ IDEA Community and Ultimate editions (version 14.1.7+) and Android Studio (version 1.2+).
+It is compatible with IntelliJ IDEA Community and Ultimate editions (version 2018.1+) and Android Studio (version 3.2+).
 
 To learn more about installing and using our Azure DevOps IntelliJ plug-in, visit: https://docs.microsoft.com/en-us/azure/devops/java/download-intellij-plug-in
 
@@ -27,43 +27,35 @@ Run the build by:
 ## Build and Run with IntelliJ
 Once you've downloaded the dependencies, run the build by:
 
-1. Start IntelliJ and open the existing IntelliJ project file `com.microsoft.alm.plugin.iml` from the `plugin` directory.
+1. Start IntelliJ and open the Gradle project from the root project directory.
 
-2. Configure a "IntelliJ Platform Plugin SDK" based on JDK 8 and IntelliJ 2017.x.
-   * File -> Project Structure -> Project Settings -> Project
-   * Under Project SDK, select the entry marked "IntelliJ IDEA <version number>" if it exists.
-     * If this entry does not exist, click New -> IntelliJ Platform Plugin SDK and select the IntelliJ installation location folder.
-       * Under Mac, the folder is similar to `/Applications/IntelliJ IDEA.app/Contents`
-       * Under Linux, the folder is similar to `<IntelliJ installation location on disk>/idea-IC-172.3968.16` 
-       * Under Windows, the folder is similar to `C:\Program Files (x86)\JetBrains\IntelliJ IDEA 2017.x`
-
-3. Configure the project to use language level JDK 8
+2. Configure the project to use language level JDK 8
    * File -> Project Structure -> Project Settings -> Project
    * Under Project Language Level, select "8 - Lambdas, type annotations etc."
 
-4. Configure the project and ***each module*** to build with this "IntelliJ Platform Plugin SDK".
+3. Configure the project and ***each module*** to build with this "IntelliJ Platform Plugin SDK".
    * File -> Project Structure -> Project Settings -> Project.
      * Under Project SDK, select the entry marked "IntelliJ IDEA <version number>".
    * File -> Project Structure -> Project Settings -> Modules -> Dependencies.
      * For each module beginning with `com.microsoft.alm` (there are three), under Module SDK, select the entry marked "IntelliJ IDEA <version number>". 
 
-5. Make sure the 'GUI designer' generates Java source code.
+4. Make sure the 'GUI designer' generates Java source code.
    * File -> Settings (on Windows) / Preferences (on Mac) -> Editor -> GUI Designer -> Generate GUI into -> Select `Java Souce Code`
 
-6. Create a "Plugin" configuration to run/debug the code.
+5. Create a "Plugin" configuration to run/debug the code.
    * Run -> Edit Configurations... -> Add -> Gradle 
    * Provide a name for the configuration (e.g., IntelliJ for TFS)
    * Set Gradle project to `plugin`
    * Set Tasks to `runIde`
 
-7. Run the plugin by selecting Run -> Run <configuration you used above>.
+6. Run the plugin by selecting Run -> Run <configuration you used above>.
 
-8. Debug the plugin by selecting Run -> Debug <configuration you used above>.
+7. Debug the plugin by selecting Run -> Debug <configuration you used above>.
 
-9. To run tests please check options on the page `Preferences | Build, Execution, Deployment | Build Tools | Gradle | Runner`
+8. To run tests please check options on the page `Preferences | Build, Execution, Deployment | Build Tools | Gradle | Runner`
     * `Delegate IDE build/run actions to gradle` should checked.
     * In `Run tests using` should select `Gradle Test Runner`
- 
+
 ## Contributing
 
 We welcome Pull Requests, please fork this repo and send us your contributions.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Azure DevOps Plugin for IntelliJ, Android Studio, & other Jetbrains IDEs
+# Azure DevOps Plugin for IntelliJ, Android Studio, & other JetBrains IDEs
 
 This is a plugin for working with Git and TFVC repositories on Azure DevOps and Team Foundation Server (TFS) 2015+ inside IntelliJ, Android Studio, 
-and various other Jetbrains IDEs. It is supported on Linux, Mac OS X, and Windows.
+and various other JetBrains IDEs. It is supported on Linux, Mac OS X, and Windows.
 It is compatible with IntelliJ IDEA Community and Ultimate editions (version 14.1.7+) and Android Studio (version 1.2+).
 
 To learn more about installing and using our Azure DevOps IntelliJ plug-in, visit: https://docs.microsoft.com/en-us/azure/devops/java/download-intellij-plug-in

--- a/config/pmd/custom-pmd-rules.xml
+++ b/config/pmd/custom-pmd-rules.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<ruleset name="TFIntellij-Plugin-Rules"
+<ruleset name="TFIntelliJ-Plugin-Rules"
    xmlns="http://pmd.sf.net/ruleset/1.0.0"
    xmlns:xsi="http://www.w1.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd">
-   <description>PMD Rules for the Intellij Plugin.</description>
+   <description>PMD Rules for the IntelliJ Plugin.</description>
    <exclude-pattern>.*/test/.*</exclude-pattern>
    <rule ref="rulesets/java/empty.xml" />
    <rule ref="rulesets/java/basic.xml" />

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 buildNumber=1.156.0
-ideaVersion=2017.2
+ideaVersion=2018.1

--- a/plugin/META-INF/plugin.xml
+++ b/plugin/META-INF/plugin.xml
@@ -47,7 +47,7 @@
       <br />
       <i>Compiled with Java 8</i>
       <br />
-      <i>Compatible with IntelliJ Ultimate and Community editions versions 14.1.7 and later and Android Studio 1.2 and later</i>
+      <i>Compatible with IntelliJ Ultimate and Community editions versions 2018.1 and later and Android Studio 3.2 and later</i>
       <br />
       <br />
       <b>End User License Agreement & Privacy Policy</b>
@@ -69,8 +69,8 @@
     ]]>
     </change-notes>
 
-    <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-    <idea-version since-build="131"/>
+    <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
+    <idea-version since-build="181"/>
 
     <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
          on how to target different products -->

--- a/plugin/src/com/microsoft/alm/plugin/idea/git/ui/pullrequest/CreatePullRequestModel.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/ui/pullrequest/CreatePullRequestModel.java
@@ -583,7 +583,7 @@ public class CreatePullRequestModel extends AbstractModel {
                     //user cancelled login, don't retry
                 }
             } else {
-                // catch everything so we don't bubble up to Intellij
+                // catch everything so we don't bubble up to IntelliJ
                 final Pair<PullRequestHelper.PRCreateStatus, String> parsed
                         = pullRequestHelper.parseException(t, branchNameOnRemoteServer, targetBranch, context, gitClient);
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeList.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeList.java
@@ -126,7 +126,7 @@ public class TFSChangeList implements CommittedChangeList {
      * NOTE: the tf tool shows a rename as 2 changes ('rename' and 'delete source rename') but there is no way to reliably
      * tell which 'rename' change goes with which 'delete source rename' change if there are multiple renames in a changeset.
      * To deal with this, we will treat the 'delete source rename' changes as deletes and 'rename' changes as adds. This
-     * is what Jetbrains did as well so it doesn't differ from their experience.
+     * is what JetBrains did as well so it doesn't differ from their experience.
      *
      * @return
      */

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeProvider.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeProvider.java
@@ -49,7 +49,7 @@ import java.util.List;
 /**
  * Extends the VCS change provider to execture the correct events to find out the local changes in the workspace
  * <p/>
- * TODO (Jetbrains) important cases
+ * TODO (JetBrains) important cases
  * 1. when folder1 is unversioned and folder1/file1 is scheduled for addition, team explorer effectively shows folder1 as scheduled for addition
  */
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSCheckinEnvironment.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSCheckinEnvironment.java
@@ -238,7 +238,7 @@ public class TFSCheckinEnvironment implements CheckinEnvironment {
 
     @Nullable
     public List<VcsException> scheduleUnversionedFilesForAddition(final List<VirtualFile> files) {
-        // TODO: schedule parent folders? (Jetbrains)
+        // TODO: schedule parent folders? (JetBrains)
         final List<VcsException> exceptions = new ArrayList<VcsException>();
         try {
             final List<String> filesToAddPaths = new ArrayList<String>(files.size());

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSCommittedChangesProvider.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSCommittedChangesProvider.java
@@ -131,7 +131,7 @@ public class TFSCommittedChangesProvider implements CachingCommittedChangesProvi
                                      final RepositoryLocation location,
                                      final int maxCount,
                                      final AsynchConsumer consumer) throws VcsException {
-        // TODO: (Jetbrains) if revision and date filters are both set, which one should have priority?
+        // TODO: (JetBrains) if revision and date filters are both set, which one should have priority?
         VersionSpec versionFrom = VersionSpec.create(1);
         if (settings.getChangeAfterFilter() != null) {
             versionFrom = VersionSpec.create((int) settings.getChangeAfterFilter().longValue());
@@ -231,7 +231,7 @@ public class TFSCommittedChangesProvider implements CachingCommittedChangesProvi
     }
 
     public boolean refreshIncomingWithCommitted() {
-        // TODO (Jetbrains)
+        // TODO (JetBrains)
         return false;
     }
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileListener.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileListener.java
@@ -98,7 +98,7 @@ public class TFSFileListener extends VcsVFSListener {
                     public void checkedOutForEdit(final @NotNull FilePath localPath,
                                                   final boolean localItemExists,
                                                   final @NotNull ServerStatus serverStatus) {
-                        // TODO (Jetbrains): add local conflict
+                        // TODO (JetBrains): add local conflict
                     }
 
                     @Override
@@ -115,24 +115,24 @@ public class TFSFileListener extends VcsVFSListener {
                     public void scheduledForDeletion(final @NotNull FilePath localPath,
                                                      final boolean localItemExists,
                                                      final @NotNull ServerStatus serverStatus) {
-                        // TODO (Jetbrains): add local conflict
+                        // TODO (JetBrains): add local conflict
                     }
 
                     public void renamed(final @NotNull FilePath localPath, final boolean localItemExists, final @NotNull ServerStatus serverStatus)
                             throws TfsException {
-                        // TODO (Jetbrains): add local conflict
+                        // TODO (JetBrains): add local conflict
                     }
 
                     public void renamedCheckedOut(final @NotNull FilePath localPath,
                                                   final boolean localItemExists,
                                                   final @NotNull ServerStatus serverStatus) throws TfsException {
-                        // TODO (Jetbrains): add local conflict
+                        // TODO (JetBrains): add local conflict
                     }
 
                     public void undeleted(final @NotNull FilePath localPath,
                                           final boolean localItemExists,
                                           final @NotNull ServerStatus serverStatus) throws TfsException {
-                        // TODO (Jetbrains): add local conflict
+                        // TODO (JetBrains): add local conflict
                     }
 
                 }, pendingChange);

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSUpdateEnvironment.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSUpdateEnvironment.java
@@ -116,7 +116,7 @@ public class TFSUpdateEnvironment implements UpdateEnvironment {
             exceptions.add(TFSVcs.convertToVcsException(e));
         }
 
-        // TODO (Jetbrains) content roots can be renamed while executing
+        // TODO (JetBrains) content roots can be renamed while executing
         TfsFileUtil.refreshAndInvalidate(tfsVcs.getProject(), contentRoots, false);
 
         return new UpdateSession() {

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/StatusProvider.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/StatusProvider.java
@@ -33,7 +33,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-// Note: if item is renamed (moved), same local item and pending change reported by server for source and target names (Jetbrains)
+// Note: if item is renamed (moved), same local item and pending change reported by server for source and target names (JetBrains)
 
 /**
  * Determines a file's state and provides it to the local changes menu

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/conflicts/DialogContentMerger.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/conflicts/DialogContentMerger.java
@@ -58,13 +58,13 @@ public class DialogContentMerger implements ContentMerger {
                 c.getRightPanelTitle(localFile, serverVersion)
         });
 
-        // TODO (Jetbrains) call canShow() first
+        // TODO (JetBrains) call canShow() first
         DiffManager.getInstance().getDiffTool().show(request);
         if (request.getResult() == DialogWrapper.OK_EXIT_CODE) {
             return true;
         } else {
             request.restoreOriginalContent();
-            // TODO (Jetbrains) maybe MergeVersion.MergeDocumentVersion.restoreOriginalContent() should save document itself?
+            // TODO (JetBrains) maybe MergeVersion.MergeDocumentVersion.restoreOriginalContent() should save document itself?
             ApplicationManager.getApplication().runWriteAction(new Runnable() {
                 public void run() {
                     final Document document = FileDocumentManager.getInstance().getDocument(localFile);

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/conflicts/ResolveConflictHelper.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/conflicts/ResolveConflictHelper.java
@@ -466,14 +466,14 @@ public class ResolveConflictHelper {
 
     public void skip(final @NotNull String conflict) {
         if (updatedFiles != null) {
-            // Jetbrains used null for version number in this case
+            // JetBrains used null for version number in this case
             updatedFiles.getGroupById(FileGroup.SKIPPED_ID).add(conflict, TFSVcs.getKey(), null);
         }
     }
 
     public void skip(final @NotNull List<Conflict> conflicts) {
         for (final Conflict conflict : conflicts) {
-            // Jetbrains used null for version number in this case
+            // JetBrains used null for version number in this case
             skip(conflict.getLocalPath());
         }
     }

--- a/plugin/test/com/microsoft/alm/plugin/idea/IdeaAbstractTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/IdeaAbstractTest.java
@@ -14,10 +14,12 @@ import com.microsoft.alm.plugin.idea.common.services.ServerContextStoreImpl;
 import com.microsoft.alm.plugin.services.AsyncService;
 import com.microsoft.alm.plugin.services.PluginServiceProvider;
 import org.junit.BeforeClass;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 
 /**
  * This class assures the the plugin service provider is initialized for all tests.
  */
+@PowerMockIgnore("javax.swing.*")
 public class IdeaAbstractTest extends AbstractTest {
 
     @BeforeClass

--- a/plugin/test/com/microsoft/alm/plugin/idea/git/ui/pullrequest/PRGitObjectMockHelper.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/git/ui/pullrequest/PRGitObjectMockHelper.java
@@ -10,6 +10,7 @@ import com.intellij.vcs.log.impl.HashImpl;
 import git4idea.GitCommit;
 import git4idea.GitLocalBranch;
 import git4idea.GitRemoteBranch;
+import git4idea.history.GitLogUtil;
 import git4idea.repo.GitRemote;
 
 import java.util.Arrays;
@@ -58,6 +59,12 @@ public class PRGitObjectMockHelper {
                 Arrays.asList(HashImpl.build("9afa081effdaeafdff089b2aa3543415f6cdb1fb")),
                 date,
                 root,
-                subject, user, message, user, date, Collections.EMPTY_LIST);
+                subject,
+                user,
+                message,
+                user,
+                date,
+                Collections.EMPTY_LIST,
+                GitLogUtil.DiffRenameLimit.GIT_CONFIG);
     }
 }


### PR DESCRIPTION
Previously, we were stating in our `plugin.xml` that we support IntelliJ IDEA version 13.1. We've also been stating the support for **other** versions of IDEA (14.1.7) and Android Studio (1.2 which is based on IDEA 14.1) in the plugin description in the `plugin.xml` and in the `README.md`. All of these statements were out of order: actually, we were only testing the plugin on 2017.2+, and it wouldn't likely work on and IDEA older than that.

This PR bumps the supported version to 2018.1 (not that big step from 2017.2, so we don't expect much user complaints), and also makes a consistent update for all the places where we're stating the supported version: in the documentation, in the `plugin.xml`, and also in the build settings.

For now (in the forseeable future), we plan to support the major IDEA versions that
- either were themselves first released more recently than a year ago (we'll look only at the date of the _initial_ release for major version, not at the date of the latest bugfix, because otherwise out-of-bound critical bugfixes could make us support everything forever, and we don't want that)
- or serve as a base platform for Android Studio released more recently than a year ago

Based on this policy:
- IDEA 2018.3 is the oldest version that was released under a year ago (in November 2018)
- Android Studio 3.2 is the oldest version that was released under a year ago (in September 2018) and is based on IntelliJ IDEA 2018.1

Thus, we'll support 2018.1+ in the next plugin release.

I have also fixed a bunch of small typos across the codebase: "Intellij" → "IntelliJ" and "Jetbrains" → "JetBrains" :)