### PR TITLE
Remove an unnecessary project name check (#250)

### DIFF
--- a/plugin/src/com/microsoft/alm/plugin/context/ServerContextManager.java
+++ b/plugin/src/com/microsoft/alm/plugin/context/ServerContextManager.java
@@ -385,7 +385,6 @@ public class ServerContextManager {
 
     public ServerContext createContextFromTfvcServerUrl(final String tfvcServerUrl, final String teamProjectName, final boolean prompt) {
         ArgumentHelper.checkNotEmptyString(tfvcServerUrl, "tfvcServerUrl");
-        ArgumentHelper.checkNotEmptyString(teamProjectName, "teamProjectName");
 
         // Get matching context from manager
         ServerContext context = get(tfvcServerUrl);


### PR DESCRIPTION
Closes #250.

Turns out everything works without this check (i.e. when the project name is actually empty), so let's just drop it.