### PR TITLE
Add comparison method into TFSContentRevision

### DIFF
--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/revision/TFSContentRevision.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/revision/TFSContentRevision.java
@@ -32,6 +32,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Creates a revision object for a file so that comparisons can be done between them
@@ -155,5 +156,22 @@ public abstract class TFSContentRevision implements ContentRevision {
     @NonNls
     public String toString() {
         return "TFSContentRevision [file=" + getFile() + ", revision=" + ((TfsRevisionNumber) getRevisionNumber()).getValue() + "]";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TFSContentRevision that = (TFSContentRevision) o;
+        return Objects.equals(getFile(), that.getFile())
+                && Objects.equals(project, that.project)
+                && getChangeset() == that.getChangeset()
+                && Objects.equals(getFilePath(), that.getFilePath())
+                && Objects.equals(getRevisionNumber(), that.getRevisionNumber());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getFile(), project, getChangeset(), getFilePath(), getRevisionNumber());
     }
 }


### PR DESCRIPTION
New commit layout in IDEA constantly tries to ask for diff, and caches the result for efficiency. Without proper equality in TFSContentRevision, the cache won't work, and IDEA will constantly recalculate the diff.

Closes #267.