### PR TITLE
Fix file system tree invalidation

### DIFF
--- a/client/backend/src/main/kotlin/com/microsoft/tfs/watcher/ExternallyControlledPathWatcher.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/watcher/ExternallyControlledPathWatcher.kt
@@ -61,15 +61,16 @@ class ExternallyControlledPathWatcher(
     override fun isWatching(): Boolean = currentSessionLifetime.isAlive
 
     override fun poll(): PathWatcherReport {
-        val (fullyInvalidated, changes) = synchronized(lock) {
-            val paths = changedPaths.toList()
+        val fullyInvalidated: Boolean
+        val changes: List<Path>
+        synchronized(lock) {
+            changes = changedPaths.toList()
             changedPaths.clear()
 
-            val fullyInvalidated = isFullyInvalidated
+            fullyInvalidated = isFullyInvalidated
             isFullyInvalidated = false
-
-            Pair(fullyInvalidated, paths)
         }
+
         return PathWatcherReport(false).apply {
             for (changedPath in changes) {
                 addChangedPath(changedPath.toString())

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeProvider.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeProvider.java
@@ -61,7 +61,7 @@ public class TFSChangeProvider implements ChangeProvider {
     }
 
     public boolean isModifiedDocumentTrackingRequired() {
-        return true;
+        return false;
     }
 
     public void doCleanup(final List<VirtualFile> files) {


### PR DESCRIPTION
This PR has two distinct changes that improve the situation with the **Local Changes** tab for both classic and reactive clients.

First of all, TFVC clients never pick up the unsaved changes from the editor anyway, so the `isModifiedDocumentTrackingRequired` flag shouldn't be set to true. This change will improve the UX a little bit for both clients, because they won't update the change lists before any changes are actually made in the file system.

But this flag was breaking the new reactive client even more, because the client won't properly pick up the changes after manual refresh: manual refresh triggers invalidation of the root item in the tree, and the subsequent save won't trigger any invalidation at all.

So, I've decided to make the **Refresh** button to trigger invalidation of the whole file system tree as intended, by doing small enhancement of our reactive file system watcher. TFS SDK already have the necessary API, so I just had to start using it.

Closes #269.