### PR TITLE
Reactive client: root invalidation issues

### DIFF
--- a/client/backend/src/main/kotlin/com/microsoft/tfs/watcher/ExternallyControlledPathWatcher.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/watcher/ExternallyControlledPathWatcher.kt
@@ -98,13 +98,15 @@ class ExternallyControlledPathWatcher(
                 shouldFullyInvalidate = true
                 break
             } else if (path.toFile().isDirectory) {
-                // Path watchers in TFS SDK doesn't currently support recursive invalidation, so we could either
-                // enumerate all the files as invalidated ourselves, or report a full invalidation (even if it's too
-                // greedy).
-                // For now, we'll always report full invalidation because, in most cases (or maybe even all of them?),
-                // IDEA asks for recursive directory invalidation when a user has pressed a "Refresh" button manually or
-                // something major happened, like a check-in.
-                logger.info { "Fully invalidating watcher for path $pathToWatch because path $path points to a directory" }
+                // Path watchers in TFS SDK don't currently support recursive invalidation, so we could either enumerate
+                // all the files as invalidated ourselves, or report a full invalidation (even if it's too greedy).
+                //
+                // For now, we'll always report full invalidation: in most cases (or maybe even all of them?), IDEA asks
+                // for recursive directory invalidation when a user has pressed a "Refresh" button manually or something
+                // major happened, like a check-in.
+                logger.info {
+                    "Fully invalidating watcher for path $pathToWatch because path $path points to a directory"
+                }
                 shouldFullyInvalidate = true
                 break
             } else if (path.startsWith(pathToWatch))

--- a/client/backend/src/main/kotlin/com/microsoft/tfs/watcher/ExternallyControlledPathWatcher.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/watcher/ExternallyControlledPathWatcher.kt
@@ -9,6 +9,7 @@ import com.jetbrains.rd.util.lifetime.LifetimeDefinition
 import com.jetbrains.rd.util.lifetime.SequentialLifetimes
 import com.jetbrains.rd.util.lifetime.isAlive
 import com.jetbrains.rd.util.reactive.Signal
+import com.jetbrains.rd.util.trace
 import com.microsoft.tfs.Logging
 import com.microsoft.tfs.core.clients.versioncontrol.localworkspace.PathWatcher
 import com.microsoft.tfs.core.clients.versioncontrol.localworkspace.PathWatcherReport
@@ -78,6 +79,8 @@ class ExternallyControlledPathWatcher(
             if (fullyInvalidated) {
                 fullyInvalidate()
             }
+
+            logger.trace { "Returning PathWatcherReport (fullyInvalidated = ${this.fullyInvalidated}, nothingChanged = $isNothingChanged) with paths:\n" + changedPaths.joinToString("\n") }
         }
     }
 
@@ -89,6 +92,7 @@ class ExternallyControlledPathWatcher(
                     if (path == pathToWatch)
                         isFullyInvalidated = true
                     changedPaths.add(path)
+                    logger.trace { "Emitting changed path signal: $path" }
                 }
             }
             workspaceWatcher.pathChanged(this)

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeProvider.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeProvider.java
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Extends the VCS change provider to execture the correct events to find out the local changes in the workspace
@@ -103,13 +102,7 @@ public class TFSChangeProvider implements ChangeProvider {
         List<PendingChange> changes;
         try {
             ServerContext serverContext = myVcs.getServerContext(true);
-            if (logger.isDebugEnabled())
-                logger.debug("Asking the client for changes in paths:\n" + StringUtils.join(pathsToProcess, "\n"));
             changes = TfvcClient.getInstance(project).getStatusForFiles(serverContext, pathsToProcess);
-            if (logger.isDebugEnabled()) {
-                List<String> fileNames = changes.stream().map(PendingChange::getLocalItem).collect(Collectors.toList());
-                logger.debug("Got answer from the client:\n" + StringUtils.join(fileNames, "\n"));
-            }
         } catch (final Throwable t) {
             logger.error("Failed to get changes from command line. roots=" + StringUtils.join(pathsToProcess, ", "), t);
             changes = Collections.emptyList();

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeProvider.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSChangeProvider.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Extends the VCS change provider to execture the correct events to find out the local changes in the workspace
@@ -102,7 +103,13 @@ public class TFSChangeProvider implements ChangeProvider {
         List<PendingChange> changes;
         try {
             ServerContext serverContext = myVcs.getServerContext(true);
+            if (logger.isDebugEnabled())
+                logger.debug("Asking the client for changes in paths:\n" + StringUtils.join(pathsToProcess, "\n"));
             changes = TfvcClient.getInstance(project).getStatusForFiles(serverContext, pathsToProcess);
+            if (logger.isDebugEnabled()) {
+                List<String> fileNames = changes.stream().map(PendingChange::getLocalItem).collect(Collectors.toList());
+                logger.debug("Got answer from the client:\n" + StringUtils.join(fileNames, "\n"));
+            }
         } catch (final Throwable t) {
             logger.error("Failed to get changes from command line. roots=" + StringUtils.join(pathsToProcess, ", "), t);
             changes = Collections.emptyList();


### PR DESCRIPTION
Sometimes, IDEA wants us to recursively invalidate the VCS root. This PR fixes some troubles that reactive client has with these requests in weird cases (when the VCS root doesn't correspond to the workspace root, but lies below or above it instead).

This makes sure that the **Refresh** button on the **Local Changes** tab always works correctly and invalidates everything it should.

Closes #273.