### PR TITLE
Fix for case-insensitive file systems and IDEA change provider

### DIFF
--- a/plugin/META-INF/plugin.xml
+++ b/plugin/META-INF/plugin.xml
@@ -59,8 +59,10 @@
     <change-notes><![CDATA[
       <br />
       <ul>
-        <li>Fixed compatibility with products based on IDEA 2019.3 (<a href="https://github.com/microsoft/azure-devops-intellij/pull/258">#258</a>)</li>
         <li>Added an experimental reactive TFVC client which provides better performance. To enable the experimental client, visit Settings | Version Control | TFVC (<a href="https://github.com/microsoft/azure-devops-intellij/pull/257">#257</a>)</li>
+        <li>Fixed compatibility with products based on IDEA 2019.3 (<a href="https://github.com/microsoft/azure-devops-intellij/pull/258">#258</a>)</li>
+        <li>Fixed a performance issue with the new VCS layout (enabled by default in JetBrains Rider) (<a href="https://github.com/microsoft/azure-devops-intellij/issues/267">#267</a>)</li>
+        <li>Fixed an issue with change detection on case-insensitive file systems when the repository was created in wrong case (<a href="https://github.com/microsoft/azure-devops-intellij/issues/274">#274</a>)</li>
       </ul>
       <br />
     ]]>

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/VersionControlPath.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/VersionControlPath.java
@@ -71,11 +71,10 @@ public class VersionControlPath {
             return null;
         }
 
-        final String systemDependent = FileUtil.toSystemDependentName(localPath);
-        if (!SystemInfo.isWindows && systemDependent.startsWith(FAKE_DRIVE_PREFIX)) {
-            return canonicalizePath(systemDependent.substring(FAKE_DRIVE_PREFIX.length()));
+        if (!SystemInfo.isWindows && localPath.startsWith(FAKE_DRIVE_PREFIX)) {
+            return canonicalizePath(localPath.substring(FAKE_DRIVE_PREFIX.length()));
         } else {
-            return canonicalizePath(systemDependent);
+            return canonicalizePath(localPath);
         }
     }
 

--- a/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/tfs/VersionControlPathTests.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/tfs/VersionControlPathTests.java
@@ -1,0 +1,34 @@
+package com.microsoft.alm.plugin.idea.tfvc.core.tfs;
+
+import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.util.io.FileUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+public class VersionControlPathTests {
+    @Test
+    public void localPathFromTfsRepresentationShouldConvertPathCase() throws IOException {
+        File tempDirectory = FileUtil.createTempDirectory("azure-devops", ".tmp");
+        try {
+            File tempFile = tempDirectory.toPath().resolve("CASE_SENSITIVE.tmp").toFile();
+            Assert.assertTrue(tempFile.createNewFile());
+
+            String tfsRepresentation = tempFile.getAbsolutePath();
+            // On non-Windows systems, TFS uses a "fake drive" prefix:
+            if (!SystemInfo.isWindows)
+                tfsRepresentation = "U:" + tfsRepresentation;
+
+            String localPath = VersionControlPath.localPathFromTfsRepresentation(tfsRepresentation);
+            Assert.assertEquals(tempFile.getAbsolutePath(), localPath);
+
+            tfsRepresentation = tfsRepresentation.toLowerCase();
+            localPath = VersionControlPath.localPathFromTfsRepresentation(tfsRepresentation);
+            Assert.assertEquals(tempFile.getAbsolutePath(), localPath);
+        } finally {
+            FileUtil.delete(tempDirectory);
+        }
+    }
+}

--- a/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/tfs/VersionControlPathTests.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/tfs/VersionControlPathTests.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
 package com.microsoft.alm.plugin.idea.tfvc.core.tfs;
 
 import com.intellij.openapi.util.SystemInfo;


### PR DESCRIPTION
The change provider should report paths in the same case as they are on disk. Otherwise, there will be random omissions of changes (see #274 for details).

Closes #274.