### PR TITLE
Remove user information from URLs used for pull requests

### DIFF
--- a/plugin/src/com/microsoft/alm/plugin/idea/git/ui/pullrequest/PullRequestHelper.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/ui/pullrequest/PullRequestHelper.java
@@ -133,8 +133,9 @@ public class PullRequestHelper {
      * @return html document with link to specified pull request
      */
     public String getHtmlMsg(final String repositoryRemoteUrl, final int id) {
+        String url = UrlHelper.removeUserInfo(repositoryRemoteUrl);
         final String text = TfPluginBundle.message(TfPluginBundle.KEY_CREATE_PR_CREATED_MESSAGE, String.valueOf(id));
-        final String webAccessUrl = String.format(WEB_ACCESS_PR_FORMAT, repositoryRemoteUrl, id);
+        final String webAccessUrl = String.format(WEB_ACCESS_PR_FORMAT, url, id);
         return String.format(UrlHelper.SHORT_HTTP_LINK_FORMATTER, webAccessUrl, text);
     }
 

--- a/plugin/test/com/microsoft/alm/plugin/idea/git/ui/pullrequest/PullRequestHelperTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/git/ui/pullrequest/PullRequestHelperTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
@@ -158,4 +159,10 @@ public class PullRequestHelperTest extends IdeaAbstractTest {
         assertEquals(PRCreateStatus.DUPLICATE, parsed.getFirst());
     }
 
+    @Test
+    public void pullRequestUrlShouldNotContainUserName() {
+        String url = "https://username@dev.azure.com/username/projectName/_git/projectName";
+        String message = underTest.getHtmlMsg(url, 100500);
+        assertFalse("\"" + message + "\" should not contain \"username@\"", message.contains("username@"));
+    }
 }


### PR DESCRIPTION
Closes #280.
Supersedes #281.

It turns out that the problem was caused by URLs passed to the browser sometimes starting from `username@`: in such case, browser security policy was messing with Azure DevOps client scripts that were trying to use HTML5 History API.

Thanks to @baltuonis for reporting the issue and suggesting an initial fix: this helped me to quickly find and fix the problem.