### PR TITLE
Use explicit XPathFactoryImpl constructor

### DIFF
--- a/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
@@ -17,6 +17,7 @@ import com.microsoft.alm.plugin.external.exceptions.ToolParseFailureException;
 import com.microsoft.alm.plugin.external.models.Workspace;
 import com.microsoft.alm.plugin.external.tools.TfTool;
 import com.microsoft.alm.plugin.external.utils.WorkspaceHelper;
+import com.sun.org.apache.xpath.internal.jaxp.XPathFactoryImpl;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +30,6 @@ import sun.security.util.Debug;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -289,7 +289,7 @@ public abstract class Command<T> {
             xmlInput = new InputSource(new StringReader(stdout));
         }
 
-        final XPath xpath = XPathFactory.newInstance().newXPath();
+        final XPath xpath = new XPathFactoryImpl().newXPath();
         try {
             final Object result = xpath.evaluate(xpathQuery, xmlInput, XPathConstants.NODESET);
             if (result != null && result instanceof NodeList) {


### PR DESCRIPTION
`XPathFactory` is incredibly ancient technology that scans some sort of configuration files available in the classpath when we ask it to provide us an instance. Sometimes it could throw an error if newer confiuration files are available in the classpath and it's unable to read them.

Often it breaks my debug sessions with the following error:
```
java.lang.RuntimeException: XPathFactory#newInstance() failed to create an XPathFactory for the default object model: http://java.sun.com/jaxp/xpath/dom with the XPathFactoryConfigurationException: java.util.ServiceConfigurationError: javax.xml.xpath.XPathFactory: jar:file:/C:/work/dotnet-products.201/Rider/ultimate/community/plugins/xslt-debugger/engine/impl/lib/saxon9he.jar!/META-INF/services/javax.xml.xpath.XPathFactory:2: Illegal configuration-file syntax
	at java.xml/javax.xml.xpath.XPathFactory.newInstance(XPathFactory.java:119)
	at com.microsoft.alm.plugin.external.commands.Command.evaluateXPath(Command.java:292)
	at com.microsoft.alm.plugin.external.commands.StatusCommand.parseOutput(StatusCommand.java:68)
	at com.microsoft.alm.plugin.external.commands.StatusCommand.parseOutput(StatusCommand.java:24)
	at com.microsoft.alm.plugin.external.commands.Command$1.completed(Command.java:178)
	at com.microsoft.alm.plugin.external.ToolRunner$ListenerProxy.completed(ToolRunner.java:295)
	at com.microsoft.alm.plugin.external.ToolRunner$ProcessWaiter.run(ToolRunner.java:333)
Caused by: javax.xml.xpath.XPathFactoryConfigurationException: java.util.ServiceConfigurationError: javax.xml.xpath.XPathFactory: jar:file:/C:/work/dotnet-products.201/Rider/ultimate/community/plugins/xslt-debugger/engine/impl/lib/saxon9he.jar!/META-INF/services/javax.xml.xpath.XPathFactory:2: Illegal configuration-file syntax
	at java.xml/javax.xml.xpath.XPathFactoryFinder.findServiceProvider(XPathFactoryFinder.java:346)
	at java.xml/javax.xml.xpath.XPathFactoryFinder._newFactory(XPathFactoryFinder.java:212)
	at java.xml/javax.xml.xpath.XPathFactoryFinder.newFactory(XPathFactoryFinder.java:137)
	at java.xml/javax.xml.xpath.XPathFactory.newInstance(XPathFactory.java:223)
	at java.xml/javax.xml.xpath.XPathFactory.newInstance(XPathFactory.java:113)
	... 6 more
Caused by: java.util.ServiceConfigurationError: javax.xml.xpath.XPathFactory: jar:file:/C:/work/dotnet-products.201/Rider/ultimate/community/plugins/xslt-debugger/engine/impl/lib/saxon9he.jar!/META-INF/services/javax.xml.xpath.XPathFactory:2: Illegal configuration-file syntax
	at java.base/java.util.ServiceLoader.fail(ServiceLoader.java:588)
	at java.base/java.util.ServiceLoader.fail(ServiceLoader.java:594)
	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.parseLine(ServiceLoader.java:1139)
	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.parse(ServiceLoader.java:1169)
	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.nextProviderClass(ServiceLoader.java:1205)
	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1220)
	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1264)
	at java.base/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1299)
	at java.base/java.util.ServiceLoader$3.hasNext(ServiceLoader.java:1384)
	at java.xml/javax.xml.xpath.XPathFactoryFinder$2.run(XPathFactoryFinder.java:335)
	at java.xml/javax.xml.xpath.XPathFactoryFinder$2.run(XPathFactoryFinder.java:331)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.xml/javax.xml.xpath.XPathFactoryFinder.findServiceProvider(XPathFactoryFinder.java:331)
	... 10 more
```

This PR will fix any issues that were caused these cases. It is a known problem and there's no other simple workaround.