### PR TITLE
Bump IDEA compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a plugin for working with Git and TFVC repositories on Azure DevOps and Team Foundation Server (TFS) 2015+ inside IntelliJ, Android Studio, 
 and various other JetBrains IDEs. It is supported on Linux, Mac OS X, and Windows.
-It is compatible with IntelliJ IDEA Community and Ultimate editions (version 2018.1+) and Android Studio (version 3.2+).
+It is compatible with IntelliJ IDEA Community and Ultimate editions (version 2018.2+) and Android Studio (version 3.3+).
 
 To learn more about installing and using our Azure DevOps IntelliJ plug-in, visit: https://docs.microsoft.com/en-us/azure/devops/java/download-intellij-plug-in
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 buildNumber=1.158.0
-ideaVersion=2018.1
+ideaVersion=2018.2
 
 kotlin.code.style=official

--- a/plugin/META-INF/plugin.xml
+++ b/plugin/META-INF/plugin.xml
@@ -47,7 +47,7 @@
       <br />
       <i>Compiled with Java 8</i>
       <br />
-      <i>Compatible with IntelliJ Ultimate and Community editions versions 2018.1 and later and Android Studio 3.2 and later</i>
+      <i>Compatible with IntelliJ Ultimate and Community editions versions 2018.2 and later and Android Studio 3.3 and later</i>
       <br />
       <br />
       <b>End User License Agreement & Privacy Policy</b>

--- a/plugin/src/com/microsoft/alm/plugin/idea/git/extensions/TfGitHttpAuthDataProvider.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/extensions/TfGitHttpAuthDataProvider.java
@@ -32,19 +32,13 @@ public class TfGitHttpAuthDataProvider implements GitHttpAuthDataProvider {
     private static final Logger logger = LoggerFactory.getLogger(TfGitHttpAuthDataProvider.class);
 
     /**
-     * This is a method that was introduced into {@link GitHttpAuthDataProvider} in IDEA 2018.2. Azure DevOps plugin is
-     * still compatible with IDEA 2017, thus we cannot properly mark this method as @Override.
-     *
-     * It is important that we override this method in IDEA 2018.2+, because
-     * {@link GitHttpAuthDataProvider#getAuthData(String)} override won't receive the `username@` as part of the URL
-     * starting from this version of IDEA. So we have to add the username to the URL ourselves, because the internal
-     * Azure authentication mechanism requires the URL combined with the username.
-     *
-     * Despite not marked as @Override, this method still overrides the interface method in IDEA 2018.2+, because this
-     * is how Java ABI works.
+     * It is important that we override this method, because {@link GitHttpAuthDataProvider#getAuthData(String)}
+     * override won't receive the `username@` as part of the URL starting from this version of IDEA. So we have to add
+     * the username to the URL ourselves, because the internal Azure authentication mechanism requires the URL combined
+     * with the username.
      */
     @Nullable
-    // @Override // HACK: It is impossible to mark this method as @Override according to the above.
+    @Override
     public AuthData getAuthData(@NotNull Project project, @NotNull String url, @NotNull String login) {
         logger.info("getAuthData: processing URL {}, login {}", url, login);
         try {
@@ -57,7 +51,7 @@ public class TfGitHttpAuthDataProvider implements GitHttpAuthDataProvider {
     }
 
     @Nullable
-    // @Override // HACK: This method was introduced in IDEA 2018.2 thus we cannot mark it as an override without raising the IDEA version
+    @Override
     public AuthData getAuthData(@NotNull Project project, @NotNull String url) {
         logger.info("getAuthData: processing URL {}", url);
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/git/starters/SimpleCheckoutStarter.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/starters/SimpleCheckoutStarter.java
@@ -3,15 +3,11 @@
 
 package com.microsoft.alm.plugin.idea.git.starters;
 
-import com.intellij.ide.IdeEventQueue;
 import com.intellij.openapi.project.DefaultProjectFactory;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vcs.CheckoutProvider;
 import com.intellij.openapi.vcs.ProjectLevelVcsManager;
 import com.intellij.openapi.vcs.VcsNotifier;
-import com.intellij.openapi.wm.WindowManager;
-import com.intellij.openapi.wm.impl.SystemDock;
-import com.intellij.openapi.wm.impl.WindowManagerImpl;
 import com.microsoft.alm.common.utils.UrlHelper;
 import com.microsoft.alm.plugin.idea.common.resources.TfPluginBundle;
 import com.microsoft.alm.plugin.idea.common.starters.StarterBase;
@@ -116,8 +112,6 @@ public class SimpleCheckoutStarter implements StarterBase {
         final CheckoutProvider.Listener listener = ProjectLevelVcsManager.getInstance(project).getCompositeCheckoutListener();
 
         try {
-            launchApplicationWindow();
-
             final SimpleCheckoutController controller = new SimpleCheckoutController(project, listener, gitUrl, ref);
             controller.showModalDialog();
         } catch (Throwable t) {
@@ -126,16 +120,6 @@ public class SimpleCheckoutStarter implements StarterBase {
             VcsNotifier.getInstance(project).notifyError(TfPluginBundle.message(TfPluginBundle.KEY_CHECKOUT_DIALOG_TITLE),
                     TfPluginBundle.message(TfPluginBundle.KEY_CHECKOUT_ERRORS_UNEXPECTED, t.getMessage()));
         }
-    }
-
-    /**
-     * Launch IntelliJ window without any project or start menu showing
-     */
-    private void launchApplicationWindow() {
-        SystemDock.updateMenu();
-        WindowManagerImpl windowManager = (WindowManagerImpl) WindowManager.getInstance();
-        IdeEventQueue.getInstance().setWindowManager(windowManager);
-        windowManager.showFrame();
     }
 
     /**

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -1,5 +1,5 @@
 jobs:
-  - job: production_build_2017_2
+  - job: production_build_2018_2
     steps:
       - task: CmdLine@1
         displayName: Run printenv

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -28,7 +28,7 @@ jobs:
           path: 'plugin/build/reports'
           artifact: '$(build.buildNumber)-reports'
 
-  - job: test_build_2019_2
+  - job: test_build_2019_3
     steps:
       - task: CmdLine@1
         displayName: Run printenv
@@ -38,7 +38,7 @@ jobs:
       - task: Gradle@1
         displayName: Gradle build (zip)
         inputs:
-          options: '--info --scan -PideaVersion=2019.2'
+          options: '--info --scan -PideaVersion=2019.3'
           tasks: clean :plugin:compileJava
           testResultsFiles: '**/TEST-*.xml'
           jdkVersionOption: 1.8


### PR DESCRIPTION
1. This PR bumps minimal supported version of IDEA to 2018.2, according to our current support policy.

   Some of the older code quirks that were used to keep compatibility with 2018.1 are now removed.

2. Also, it updates the last version we use for compilation to 2019.3.

   There was one API breakage in not so much used feature, command-line checkout. It turns out the API call that was used (`WindowManagerImpl::showFrame()`) is unnecessary, since import may be performed without any frame opened, and everything will work well afterwards (the IDE frame will be shown after successful import as usual).

   All the API issues are now fixed.