### PR TITLE
L2 test fixes

### DIFF
--- a/L2Tests/test/com/microsoft/alm/L2/L2Test.java
+++ b/L2Tests/test/com/microsoft/alm/L2/L2Test.java
@@ -293,8 +293,23 @@ public abstract class L2Test extends UsefulTestCase {
         return name;
     }
 
+    private void disposeRegisteredServerContexts() {
+        // remove and dispose all the contexts for the next test
+        for (final ServerContext context : ServerContextManager.getInstance().getAllServerContexts()) {
+            ServerContextManager.getInstance().remove(context.getKey());
+            context.dispose();
+        }
+    }
+
+    private void disposeJerseyPool() throws InterruptedException {
+        // Since there's no API to dispose Jersey thread pool, let's just give it a bit more time to shutdown the pool.
+        Thread.sleep(1000);
+    }
+
     @Override
     protected void tearDown() throws Exception {
+        disposeRegisteredServerContexts();
+        disposeJerseyPool();
         try {
             /*if (myDialogManager != null) {
                 myDialogManager.cleanup();

--- a/L2Tests/test/com/microsoft/alm/L2/common/ui/settings/PasswordMgtTests.java
+++ b/L2Tests/test/com/microsoft/alm/L2/common/ui/settings/PasswordMgtTests.java
@@ -14,7 +14,6 @@ import com.microsoft.alm.plugin.idea.common.ui.settings.TeamServicesSettingsCont
 import com.microsoft.alm.plugin.idea.common.ui.settings.TeamServicesSettingsForm;
 import com.microsoft.alm.plugin.idea.common.ui.settings.TeamServicesSettingsModel;
 import com.microsoft.alm.plugin.idea.common.utils.IdeaHelper;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,14 +42,6 @@ public class PasswordMgtTests extends L2Test {
     @Before
     public void testSetup() {
         PowerMockito.mockStatic(Messages.class);
-    }
-
-    @After
-    public void cleanup() {
-        // remove all contexts for the next test
-        for (final ServerContext context : ServerContextManager.getInstance().getAllServerContexts()) {
-            ServerContextManager.getInstance().remove(context.getKey());
-        }
     }
 
     @Test(timeout = 60000)

--- a/L2Tests/test/com/microsoft/alm/L2/git/GitImportTest.java
+++ b/L2Tests/test/com/microsoft/alm/L2/git/GitImportTest.java
@@ -12,6 +12,7 @@ import com.microsoft.alm.plugin.idea.git.ui.vcsimport.ImportModel;
 import com.microsoft.alm.plugin.idea.git.ui.vcsimport.VsoImportPageModel;
 import com.microsoft.alm.sourcecontrol.webapi.GitHttpClient;
 import com.microsoft.alm.sourcecontrol.webapi.model.GitRepository;
+import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import sun.security.util.Debug;
@@ -29,6 +30,13 @@ public class GitImportTest extends L2Test {
     public static final String GIT_FOLDER = ".git";
     public static final String README_FILE = "readme.md";
 
+    @Override
+    protected void tearDown() throws Exception {
+        File gitDirectory = new File(myProjectPath, GIT_FOLDER);
+        FileUtils.deleteDirectory(gitDirectory);
+
+        super.tearDown();
+    }
 
     @Test(timeout = 60000)
     public void testImport_VSO() throws Exception {
@@ -97,6 +105,5 @@ public class GitImportTest extends L2Test {
         bufferedContent.close();
         contentStream.close();
         selectedContext.dispose();
-        // TODO: Clean up the folder now that the test has passed
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -143,6 +143,14 @@ project(":plugin") {
 project(":L2Tests") {
     apply plugin: 'org.jetbrains.intellij'
 
+    // The plugin relies on an outdated version of jackson-databind being available in the classpath (it is a required
+    // transitive dependency of com.microsoft.alm:com.microsoft.alm.client with no newer version available). It is
+    // available in the product because of how IDEA classloaders work, but it gets overridden by IDEA's instance of
+    // jackson-databind in tests. We have to load right version of the library by moving it on top of the classpath.
+    configurations {
+        jacksonDatabind
+    }
+
     intellij {
         version = ideaVersion
         plugins = ['git4idea']
@@ -150,7 +158,7 @@ project(":L2Tests") {
 
     dependencies {
         compile project(':plugin')
-        testCompile project(':plugin').sourceSets.test.output
+        jacksonDatabind 'com.fasterxml.jackson.core:jackson-databind:2.4.1'
     }
 
     jar {
@@ -158,6 +166,7 @@ project(":L2Tests") {
     }
 
     test {
+        classpath = configurations.jacksonDatabind + (classpath - configurations.jacksonDatabind)
         forkEvery = 1
     }
 }

--- a/plugin/src/com/microsoft/alm/plugin/idea/git/actions/CreatePullRequestAction.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/actions/CreatePullRequestAction.java
@@ -13,6 +13,8 @@ import com.microsoft.alm.plugin.idea.git.ui.pullrequest.CreatePullRequestControl
 import com.microsoft.alm.plugin.idea.git.utils.TfGitHelper;
 import git4idea.repo.GitRepository;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * This class adds a "Create Pull Request" menu item to git menu.
  */
@@ -48,7 +50,17 @@ public class CreatePullRequestAction extends DumbAwareAction {
         if (gitRepository != null) {
             CreatePullRequestController createPullRequestController
                     = new CreatePullRequestController(project, gitRepository);
-            createPullRequestController.showModalDialog();
+            try {
+                createPullRequestController.showModalDialog();
+            } finally {
+                try {
+                    // We don't need synchronous dispose here, so pass zero timeout and ignore the exit code. The model
+                    // will be disposed eventually, which is okay.
+                    createPullRequestController.dispose(0, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    // ignore interruption
+                }
+            }
         }
     }
 }

--- a/plugin/src/com/microsoft/alm/plugin/idea/git/ui/pullrequest/CreatePullRequestController.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/ui/pullrequest/CreatePullRequestController.java
@@ -17,6 +17,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.Observable;
 import java.util.Observer;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Controller for CreatePullRequestDialog
@@ -61,6 +62,10 @@ public class CreatePullRequestController implements Observer, ActionListener {
                 return validate();
             }
         });
+    }
+
+    public boolean dispose(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        return createModel.dispose(timeout, timeUnit);
     }
 
     public void showModalDialog() {

--- a/plugin/src/com/microsoft/alm/plugin/idea/git/ui/pullrequest/CreatePullRequestModel.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/ui/pullrequest/CreatePullRequestModel.java
@@ -73,6 +73,7 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 
@@ -162,6 +163,11 @@ public class CreatePullRequestModel extends AbstractModel {
 
         this.executorService = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool());
         this.workItems = new HashSet<Integer>();
+    }
+
+    public boolean dispose(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        executorService.shutdown();
+        return executorService.awaitTermination(timeout, timeUnit);
     }
 
     public Project getProject() {


### PR DESCRIPTION
I've found that our L2 tests have some issues, and fixed all of them.

This also fixes one real thread pool leak in our code (the thread pools created in `CreatePullRequestModel` were never disposed).

I have plans to enable L2 testing on CI soon to not allow this happen again.