### PR TITLE
Enable file removal through the reactive client

### DIFF
--- a/client/backend/src/main/kotlin/com/microsoft/tfs/CollectionEx.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/CollectionEx.kt
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.tfs
+
+inline fun <T, reified R> List<T>.mapToArray(transform: (T) -> R): Array<R> =
+    Array(size) { idx -> transform(this[idx]) }

--- a/client/backend/src/main/kotlin/com/microsoft/tfs/Main.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/Main.kt
@@ -108,6 +108,13 @@ private fun initializeCollection(lifetime: Lifetime, definition: TfsCollectionDe
         client.invalidatePaths(paths.map { it.toJavaPath() })
     }
 
+    collection.deleteFilesRecursively.set { paths ->
+        if (paths.isEmpty()) return@set
+
+        logger.info { "Deleting ${paths.size} paths, first 10: ${paths.take(10).joinToString { it.path }}" }
+        client.deletePathsRecursively(paths.map { it.toJavaPath() })
+    }
+
     client.workspaces.advise(lifetime) { workspaces ->
         val paths = workspaces.flatMap { it.mappedPaths.map(::TfsLocalPath) }
         collection.mappedPaths.set(paths)

--- a/client/connector/src/main/kotlin/com/microsoft/tfs/connector/ReactiveClientConnection.kt
+++ b/client/connector/src/main/kotlin/com/microsoft/tfs/connector/ReactiveClientConnection.kt
@@ -72,6 +72,11 @@ class ReactiveClientConnection(private val scheduler: IScheduler) {
             collection.invalidatePaths.start(paths).pipeToVoid(lt, this)
         }
 
+    fun deleteFilesRecursivelyAsync(collection: TfsCollection, paths: List<TfsLocalPath>): CompletableFuture<Void> =
+        queueFutureAsync { lt ->
+            collection.deleteFilesRecursively.start(paths).pipeToVoid(lt, this)
+        }
+
     private fun <T> queueFutureAsync(action: CompletableFuture<T>.(Lifetime) -> Unit): CompletableFuture<T> {
         val lifetime = lifetime.createNested()
         val future = CompletableFuture<T>().whenComplete { _, _ -> lifetime.terminate() }

--- a/client/protocol/src/main/kotlin/model/tfs/TfsModel.kt
+++ b/client/protocol/src/main/kotlin/model/tfs/TfsModel.kt
@@ -60,6 +60,9 @@ object TfsModel : Root() {
 
         call("invalidatePaths", immutableList(TfsLocalPath), void)
             .doc("Invalidates the paths in the TFS cache")
+
+        call("deleteFilesRecursively", immutableList(TfsLocalPath), void)
+            .doc("Scheduled deletion of the files")
     }
 
     init {

--- a/plugin/src/com/microsoft/alm/plugin/external/reactive/ServerIdentification.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/reactive/ServerIdentification.java
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.alm.plugin.external.reactive;
+
+import com.microsoft.alm.plugin.authentication.AuthenticationInfo;
+
+import java.net.URI;
+
+public class ServerIdentification {
+    private final URI serverUri;
+    private final AuthenticationInfo authenticationInfo;
+
+    public ServerIdentification(URI serverUri, AuthenticationInfo authenticationInfo) {
+        this.serverUri = serverUri;
+        this.authenticationInfo = authenticationInfo;
+    }
+
+    public URI getServerUri() {
+        return serverUri;
+    }
+
+    public AuthenticationInfo getAuthenticationInfo() {
+        return authenticationInfo;
+    }
+}

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/ClassicTfvcClient.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/ClassicTfvcClient.java
@@ -9,6 +9,7 @@ import com.microsoft.alm.plugin.external.models.PendingChange;
 import com.microsoft.alm.plugin.external.utils.CommandUtils;
 import com.microsoft.alm.plugin.idea.tfvc.ui.settings.EULADialog;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -38,5 +39,23 @@ public class ClassicTfvcClient implements TfvcClient {
         return EULADialog.executeWithGuard(
                 myProject,
                 () -> CommandUtils.getStatusForFiles(myProject, serverContext, pathsToProcess));
+    }
+
+    @NotNull
+    @Override
+    public CompletableFuture<Void> deleteFilesRecursivelyAsync(
+            @NotNull ServerContext serverContext,
+            @Nullable String workingFolder,
+            @NotNull List<String> filePaths) {
+        deleteFilesRecursively(serverContext, workingFolder, filePaths);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void deleteFilesRecursively(
+            @NotNull ServerContext serverContext,
+            @Nullable String workingFolder,
+            @NotNull List<String> filePaths) {
+        CommandUtils.deleteFiles(serverContext, filePaths, workingFolder, true);
     }
 }

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListener.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListener.java
@@ -60,6 +60,9 @@ public class TFSFileSystemListener implements LocalFileOperationsHandler, Dispos
 
     @Override
     public boolean delete(final VirtualFile virtualFile) throws IOException {
+        long startTime = System.nanoTime();
+        ourLogger.trace("Delete command started for file " + virtualFile);
+
         final TFSVcs vcs = VcsHelper.getTFSVcsByPath(virtualFile);
         // no TFSVcs so not a TFVC project so do nothing
         if (vcs == null) {
@@ -183,6 +186,10 @@ public class TFSFileSystemListener implements LocalFileOperationsHandler, Dispos
                     Arrays.asList(filePath), pendingChanges.get(0).getWorkspace(), true);
         }
         ourLogger.info("File was deleted using TFVC: " + success.get());
+
+        long time = System.nanoTime() - startTime;
+        ourLogger.trace("Delete command finished in " + time / 1_000_000_000.0 + "s");
+
         return success.get();
     }
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TfvcClient.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TfvcClient.java
@@ -9,6 +9,7 @@ import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.external.models.PendingChange;
 import com.microsoft.alm.plugin.services.PropertyService;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -45,5 +46,18 @@ public interface TfvcClient {
             @NotNull ServerContext serverContext,
             @NotNull List<String> pathsToProcess) throws ExecutionException, InterruptedException {
         return getStatusForFilesAsync(serverContext, pathsToProcess).get();
+    }
+
+    @NotNull
+    CompletableFuture<Void> deleteFilesRecursivelyAsync(
+            @NotNull ServerContext serverContext,
+            @Nullable String workingFolder,
+            @NotNull List<String> filePaths);
+
+    default void deleteFilesRecursively(
+            @NotNull ServerContext serverContext,
+            @Nullable String workingFolder,
+            @NotNull List<String> filePaths) throws ExecutionException, InterruptedException {
+        deleteFilesRecursivelyAsync(serverContext, workingFolder, filePaths).get();
     }
 }

--- a/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListenerTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListenerTest.java
@@ -4,6 +4,7 @@
 package com.microsoft.alm.plugin.idea.tfvc.core;
 
 import com.google.common.collect.ImmutableList;
+import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vcs.FilePath;
 import com.intellij.openapi.vcs.VcsShowConfirmationOption;
@@ -44,7 +45,15 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({CommandUtils.class, TFSVcs.class, TFVCUtil.class, LocalFileSystem.class, VersionControlPath.class, VcsHelper.class})
+@PrepareForTest({
+        CommandUtils.class,
+        LocalFileSystem.class,
+        ServiceManager.class,
+        TFSVcs.class,
+        TFVCUtil.class,
+        VcsHelper.class,
+        VersionControlPath.class,
+})
 public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     private String CURRENT_FILE_NAME = "file.txt";
     private String NEW_FILE_NAME = "newName.txt";
@@ -72,6 +81,9 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     private Project mockProject;
 
     @Mock
+    private TfvcClient mockTfvcClient;
+
+    @Mock
     private ServerContext mockServerContext;
 
     @Mock
@@ -86,8 +98,17 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        PowerMockito.mockStatic(CommandUtils.class, TFSVcs.class, TFVCUtil.class, LocalFileSystem.class, VersionControlPath.class, VcsHelper.class);
+        PowerMockito.mockStatic(
+                CommandUtils.class,
+                LocalFileSystem.class,
+                ServiceManager.class,
+                TFSVcs.class,
+                TFVCUtil.class,
+                VcsHelper.class,
+                VersionControlPath.class
+        );
 
+        when(ServiceManager.getService(eq(mockProject), any())).thenReturn(new ClassicTfvcClient(mockProject));
         when(mockTFSVcs.getProject()).thenReturn(mockProject);
         when(mockVcsShowConfirmationOption.getValue()).thenReturn(VcsShowConfirmationOption.Value.DO_ACTION_SILENTLY);
         when(mockTFSVcs.getDeleteConfirmation()).thenReturn(mockVcsShowConfirmationOption);


### PR DESCRIPTION
Closes #296.

This enables file removal using the reactive client which is significantly faster, because it doesn't need to start a new client process for each file.