### PR TITLE
Allow bundled update of the plugin

### DIFF
--- a/plugin/META-INF/plugin.xml
+++ b/plugin/META-INF/plugin.xml
@@ -60,7 +60,7 @@
       <br />
       <ul>
         <li><b>Plugin is now only compatible with IntelliJ 2018.2+ (Android Studio 3.3+)</b></li>
-        <li>Plugin now suggests to automatically enable version control if an appropriate repository is opened (<a href="https://github.com/microsoft/azure-devops-intellij/issues/284">#284</a>)</li>
+        <li>Plugin automatically enables version control if an appropriate repository is opened (<a href="https://github.com/microsoft/azure-devops-intellij/issues/284">#284</a>)</li>
         <li><b>Enable Version Control Integration</b> now should work for Visual Studio repositories (<a href="https://github.com/microsoft/azure-devops-intellij/issues/67">#67</a>)</li>
         <li>Deleting files is now a much faster operation (<a href="https://github.com/microsoft/azure-devops-intellij/issues/296">#296</a>)</li>
         <li>Small bug fixes and compatibility changes for IDEA 2020.1 (<a href="https://github.com/microsoft/azure-devops-intellij/pull/293">#293</a>)</li>

--- a/plugin/META-INF/plugin.xml
+++ b/plugin/META-INF/plugin.xml
@@ -3,7 +3,7 @@
   ~ Licensed under the MIT license. See License.txt in the project root.
   -->
 
-<idea-plugin version="2">
+<idea-plugin allow-bundled-update="true">
     <id>com.microsoft.vso.idea</id>
     <name>Azure DevOps</name>
     <!-- <version>1.155.0</version> NOTE: Version is set automatically on build, update it in gradle.properties -->


### PR DESCRIPTION
This will allow the plugin bundled into the JetBrains IDEs (the ones that choose to bundle it) to be updated when we release an update.

`version="2"` is outdated, so I've decided to remove it.

This PR also rewords the release notes a little.