### PR TITLE
Workaround for IDEA-228828: ignore some undo errors

### DIFF
--- a/client/backend/src/main/kotlin/com/microsoft/tfs/DataConversion.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/DataConversion.kt
@@ -3,14 +3,11 @@
 
 package com.microsoft.tfs
 
+import com.microsoft.tfs.core.clients.versioncontrol.path.LocalPath
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.ChangeType
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.PendingChange
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.PendingSet
-import com.microsoft.tfs.model.host.TfsLocalPath
-import com.microsoft.tfs.model.host.TfsPendingChange
-import com.microsoft.tfs.model.host.TfsServerStatusType
-import java.nio.file.Path
-import java.nio.file.Paths
+import com.microsoft.tfs.model.host.*
 import java.text.SimpleDateFormat
 
 private val isoDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
@@ -52,4 +49,8 @@ fun toPendingChanges(pendingSet: PendingSet): Iterable<TfsPendingChange> =
     (pendingSet.pendingChanges.asSequence().map { toPendingChange(pendingSet, it) }
             + pendingSet.candidatePendingChanges.map { toPendingChange(pendingSet, it) }).asIterable()
 
-fun TfsLocalPath.toJavaPath(): Path = Paths.get(path)
+fun TfsPath.toCanonicalPathString(): String = when(this) {
+    is TfsLocalPath -> LocalPath.canonicalize(path)
+    is TfsServerPath -> path
+    else -> throw Exception("Unknown path type: $this")
+}

--- a/client/backend/src/main/kotlin/com/microsoft/tfs/Main.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/Main.kt
@@ -95,7 +95,7 @@ private fun initializeCollection(lifetime: Lifetime, definition: TfsCollectionDe
 
     collection.getPendingChanges.set { paths ->
         logger.info { "Calculating pending changes for ${paths.size} paths" }
-        val result = client.status(paths.map { it.toJavaPath() }).flatMap(::toPendingChanges).toList()
+        val result = client.status(paths).flatMap(::toPendingChanges).toList()
         logger.info { "${result.size} changes detected" }
         logger.info { "First 10 changes: " + result.take(10).joinToString { it.serverItem } }
         result
@@ -104,15 +104,15 @@ private fun initializeCollection(lifetime: Lifetime, definition: TfsCollectionDe
     collection.invalidatePaths.set { paths ->
         if (paths.isEmpty()) return@set
 
-        logger.info { "Invalidating ${paths.size} paths, first 10: ${paths.take(10).joinToString { it.path }}" }
-        client.invalidatePaths(paths.map { it.toJavaPath() })
+        logger.info { "Invalidating ${paths.size} paths, first 10: ${paths.take(10).joinToString()}" }
+        client.invalidatePaths(paths)
     }
 
     collection.deleteFilesRecursively.set { paths ->
         if (paths.isEmpty()) return@set
 
-        logger.info { "Deleting ${paths.size} paths, first 10: ${paths.take(10).joinToString { it.path }}" }
-        client.deletePathsRecursively(paths.map { it.toJavaPath() })
+        logger.info { "Deleting ${paths.size} paths, first 10: ${paths.take(10).joinToString()}" }
+        client.deletePathsRecursively(paths)
     }
 
     client.workspaces.advise(lifetime) { workspaces ->

--- a/client/backend/src/main/kotlin/com/microsoft/tfs/sdk/ClientEx.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/sdk/ClientEx.kt
@@ -1,0 +1,20 @@
+package com.microsoft.tfs.sdk
+
+import com.microsoft.tfs.core.clients.versioncontrol.VersionControlClient
+import com.microsoft.tfs.core.clients.versioncontrol.exceptions.WorkspaceNotFoundException
+import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Workspace
+import com.microsoft.tfs.model.host.TfsLocalPath
+import com.microsoft.tfs.model.host.TfsPath
+import com.microsoft.tfs.model.host.TfsServerPath
+
+fun VersionControlClient.tryGetWorkspace(path: TfsPath): Workspace? = when(path) {
+    is TfsLocalPath -> tryGetWorkspace(path.path)
+    is TfsServerPath -> {
+        try {
+            getWorkspace(path.workspace, ".")
+        } catch (ex: WorkspaceNotFoundException) {
+            null
+        }
+    }
+    else -> throw Exception("Unknown path type: $path")
+}

--- a/client/backend/src/main/kotlin/com/microsoft/tfs/sdk/ClientEx.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/sdk/ClientEx.kt
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
 package com.microsoft.tfs.sdk
 
 import com.microsoft.tfs.core.clients.versioncontrol.VersionControlClient

--- a/client/backend/src/main/kotlin/com/microsoft/tfs/sdk/WorkspaceEx.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/sdk/WorkspaceEx.kt
@@ -1,0 +1,12 @@
+package com.microsoft.tfs.sdk
+
+import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Workspace
+import com.microsoft.tfs.model.host.TfsLocalPath
+import com.microsoft.tfs.model.host.TfsPath
+import com.microsoft.tfs.model.host.TfsServerPath
+
+fun Workspace.isPathMapped(path: TfsPath): Boolean = when (path) {
+    is TfsLocalPath -> isLocalPathMapped(path.path)
+    is TfsServerPath -> isServerPathMapped(path.path)
+    else -> throw Exception("Unknown path type: $path")
+}

--- a/client/backend/src/main/kotlin/com/microsoft/tfs/sdk/WorkspaceEx.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/sdk/WorkspaceEx.kt
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
 package com.microsoft.tfs.sdk
 
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Workspace

--- a/client/connector/src/main/kotlin/com/microsoft/tfs/connector/ReactiveClientConnection.kt
+++ b/client/connector/src/main/kotlin/com/microsoft/tfs/connector/ReactiveClientConnection.kt
@@ -62,7 +62,7 @@ class ReactiveClientConnection(private val scheduler: IScheduler) {
 
     fun getPendingChangesAsync(
         collection: TfsCollection,
-        paths: List<TfsLocalPath>): CompletableFuture<List<TfsPendingChange>> =
+        paths: List<TfsPath>): CompletableFuture<List<TfsPendingChange>> =
         queueFutureAsync { lt ->
             collection.getPendingChanges.start(paths).pipeTo(lt, this)
         }
@@ -72,7 +72,7 @@ class ReactiveClientConnection(private val scheduler: IScheduler) {
             collection.invalidatePaths.start(paths).pipeToVoid(lt, this)
         }
 
-    fun deleteFilesRecursivelyAsync(collection: TfsCollection, paths: List<TfsLocalPath>): CompletableFuture<Void> =
+    fun deleteFilesRecursivelyAsync(collection: TfsCollection, paths: List<TfsPath>): CompletableFuture<Void> =
         queueFutureAsync { lt ->
             collection.deleteFilesRecursively.start(paths).pipeToVoid(lt, this)
         }

--- a/client/protocol/src/main/kotlin/model/tfs/TfsModel.kt
+++ b/client/protocol/src/main/kotlin/model/tfs/TfsModel.kt
@@ -8,7 +8,14 @@ import com.jetbrains.rd.generator.nova.PredefinedType.*
 
 @Suppress("unused")
 object TfsModel : Root() {
-    private val TfsLocalPath = structdef {
+    private val TfsPath = basestruct {}
+
+    private val TfsLocalPath = structdef extends TfsPath {
+        field("path", string)
+    }
+
+    private val TfsServerPath = structdef extends TfsPath {
+        field("workspace", string)
         field("path", string)
     }
 
@@ -52,16 +59,16 @@ object TfsModel : Root() {
         property("isReady", bool)
             .doc("Whether the client is ready to accept method calls")
 
-        property("mappedPaths", immutableList(TfsLocalPath))
+        property("mappedPaths", immutableList(TfsPath))
             .doc("A list of path mappings for this collection")
 
-        call("getPendingChanges", immutableList(TfsLocalPath), immutableList(TfsPendingChange))
+        call("getPendingChanges", immutableList(TfsPath), immutableList(TfsPendingChange))
             .doc("Determines a set of the pending changes in the collection")
 
         call("invalidatePaths", immutableList(TfsLocalPath), void)
             .doc("Invalidates the paths in the TFS cache")
 
-        call("deleteFilesRecursively", immutableList(TfsLocalPath), void)
+        call("deleteFilesRecursively", immutableList(TfsPath), void)
             .doc("Scheduled deletion of the files")
     }
 

--- a/plugin/META-INF/plugin.xml
+++ b/plugin/META-INF/plugin.xml
@@ -61,6 +61,7 @@
       <ul>
         <li><b>Plugin is now only compatible with IntelliJ 2018.2+ (Android Studio 3.3+)</b></li>
         <li>Plugin automatically enables version control if an appropriate repository is opened (<a href="https://github.com/microsoft/azure-devops-intellij/issues/284">#284</a>)</li>
+        <li>Fixed an issue with file deleting in IntelliJ 2019.3+ (<a href="https://github.com/microsoft/azure-devops-intellij/issues/304">#304</a>)</li>
         <li><b>Enable Version Control Integration</b> now should work for Visual Studio repositories (<a href="https://github.com/microsoft/azure-devops-intellij/issues/67">#67</a>)</li>
         <li>Deleting files is now a much faster operation (<a href="https://github.com/microsoft/azure-devops-intellij/issues/296">#296</a>)</li>
         <li>Small bug fixes and compatibility changes for IDEA 2020.1 (<a href="https://github.com/microsoft/azure-devops-intellij/pull/293">#293</a>)</li>

--- a/plugin/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
+++ b/plugin/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
@@ -49,7 +49,7 @@ ToolException.TF.HomeNotSet=The TF command line tool must be installed and the l
 ToolException.TF.ExeNotFound=The specified path does not lead to a valid TF executable.
 ToolException.TF.BadExitCode=TF command returned non-zero exit code. Exit code = {0}
 ToolException.TF.ParseFailure=Unable to parse the output from the TF command.
-ToolException.TF.NoPendingChangesFound=No pending changes are found.
+ToolException.TF.NoPendingChangesFound=No pending changes were found.
 ToolException.TF.MinVersionWarning=The installed version of the TF command line is {0}. The minimum version suggested is {1}. You may run into errors or limitations with certain commands until you upgrade. Follow these <a href=https://docs.microsoft.com/en-us/azure/devops/java/intellij-faq?view=azure-devops#does-the-intellij-plug-in-support-tfvc>upgrade instructions</a>.
 ToolException.TF.WorkspaceCouldNotBeDetermined=The workspace could not be determined from any argument paths or the current working directory.
 ToolException.TF.WorkspaceExists=The workspace ''{0}'' already exists for you on this computer or another. Please try checking out the repository again with a different unique directory name.

--- a/plugin/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
+++ b/plugin/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
@@ -49,6 +49,7 @@ ToolException.TF.HomeNotSet=The TF command line tool must be installed and the l
 ToolException.TF.ExeNotFound=The specified path does not lead to a valid TF executable.
 ToolException.TF.BadExitCode=TF command returned non-zero exit code. Exit code = {0}
 ToolException.TF.ParseFailure=Unable to parse the output from the TF command.
+ToolException.TF.NoPendingChangesFound=No pending changes are found.
 ToolException.TF.MinVersionWarning=The installed version of the TF command line is {0}. The minimum version suggested is {1}. You may run into errors or limitations with certain commands until you upgrade. Follow these <a href=https://docs.microsoft.com/en-us/azure/devops/java/intellij-faq?view=azure-devops#does-the-intellij-plug-in-support-tfvc>upgrade instructions</a>.
 ToolException.TF.WorkspaceCouldNotBeDetermined=The workspace could not be determined from any argument paths or the current working directory.
 ToolException.TF.WorkspaceExists=The workspace ''{0}'' already exists for you on this computer or another. Please try checking out the repository again with a different unique directory name.

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/UndoCommand.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/UndoCommand.java
@@ -7,6 +7,7 @@ import com.microsoft.alm.common.utils.ArgumentHelper;
 import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.exceptions.TeamServicesException;
 import com.microsoft.alm.plugin.external.ToolRunner;
+import com.microsoft.alm.plugin.external.exceptions.NoPendingChangesFoundException;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,6 +23,7 @@ public class UndoCommand extends Command<List<String>> {
     public static final Logger logger = LoggerFactory.getLogger(UndoCommand.class);
 
     private static final String UNDO_LINE_PREFIX = "Undoing edit:";
+    private static final String NO_PENDING_CHANGES_WERE_FOUND = "No pending changes were found for ";
 
     private final List<String> files;
 
@@ -55,6 +57,11 @@ public class UndoCommand extends Command<List<String>> {
 
         // check for failure
         if (StringUtils.isNotEmpty(stderr)) {
+            if (stderr.startsWith(NO_PENDING_CHANGES_WERE_FOUND)) {
+                logger.warn("Message from the TFVC client: " + stderr);
+                throw new NoPendingChangesFoundException();
+            }
+
             logger.error("Undo failed with the following stderr: " + stderr);
             for (int i = 0; i < output.length; i++) {
                 // finding error message by eliminating all other known output lines since we can't parse for the error line itself (it's unknown to us)

--- a/plugin/src/com/microsoft/alm/plugin/external/exceptions/NoPendingChangesFoundException.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/exceptions/NoPendingChangesFoundException.java
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.alm.plugin.external.exceptions;
+
+public class NoPendingChangesFoundException extends ToolException {
+
+    public NoPendingChangesFoundException() {
+        super(KEY_TF_NO_PENDING_CHANGES_FOUND);
+    }
+}

--- a/plugin/src/com/microsoft/alm/plugin/external/exceptions/ToolException.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/exceptions/ToolException.java
@@ -39,6 +39,7 @@ public class ToolException extends RuntimeException implements LocalizedExceptio
     public static String KEY_TF_HOME_NOT_SET = "KEY_TF_HOME_NOT_SET";
     public static String KEY_TF_EXE_NOT_FOUND = "KEY_TF_EXE_NOT_FOUND";
     public static String KEY_TF_BAD_EXIT_CODE = "KEY_TF_BAD_EXIT_CODE";
+    public static String KEY_TF_NO_PENDING_CHANGES_FOUND = "KEY_TF_NO_PENDING_CHANGES_FOUND";
     public static String KEY_TF_PARSE_FAILURE = "KEY_TF_PARSE_FAILURE";
     public static String KEY_TF_MIN_VERSION_WARNING = "KEY_TF_MIN_VERSION_WARNING";
     public static String KEY_TF_WORKSPACE_COULD_NOT_BE_DETERMINED = "KEY_TF_WORKSPACE_COULD_NOT_BE_DETERMINED";

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/services/LocalizationServiceImpl.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/services/LocalizationServiceImpl.java
@@ -103,6 +103,7 @@ public class LocalizationServiceImpl implements LocalizationService {
             put(ToolException.KEY_TF_DOLLAR_IN_PATH, "ToolException.TF.DollarInPath");
             put(ToolException.KEY_TF_HOME_NOT_SET, "ToolException.TF.HomeNotSet");
             put(ToolException.KEY_TF_EXE_NOT_FOUND, "ToolException.TF.ExeNotFound");
+            put(ToolException.KEY_TF_NO_PENDING_CHANGES_FOUND, "ToolException.TF.NoPendingChangesFound");
             put(ToolException.KEY_TF_PARSE_FAILURE, "ToolException.TF.ParseFailure");
             put(ToolException.KEY_TF_MIN_VERSION_WARNING, "ToolException.TF.MinVersionWarning");
             put(ToolException.KEY_TF_WORKSPACE_COULD_NOT_BE_DETERMINED, "ToolException.TF.WorkspaceCouldNotBeDetermined");

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/ClassicTfvcClient.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/ClassicTfvcClient.java
@@ -62,7 +62,7 @@ public class ClassicTfvcClient implements TfvcClient {
         else if (path instanceof TfsServerPath)
             return Optional.of(((TfsServerPath) path).getWorkspace());
         else
-            throw new RuntimeException("Unknown subtype of TfsPath: " + path);
+            throw new RuntimeException("Unknown path type: " + path);
     }
 
     @NotNull
@@ -72,7 +72,7 @@ public class ClassicTfvcClient implements TfvcClient {
         else if (path instanceof TfsServerPath)
             return ((TfsServerPath) path).getPath();
         else
-            throw new RuntimeException("Unknown subtype of TfsPath: " + path);
+            throw new RuntimeException("Unknown path type: " + path);
     }
 
     @Override

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/ClassicTfvcClient.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/ClassicTfvcClient.java
@@ -8,11 +8,16 @@ import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.external.models.PendingChange;
 import com.microsoft.alm.plugin.external.utils.CommandUtils;
 import com.microsoft.alm.plugin.idea.tfvc.ui.settings.EULADialog;
+import com.microsoft.tfs.model.connector.TfsLocalPath;
+import com.microsoft.tfs.model.connector.TfsPath;
+import com.microsoft.tfs.model.connector.TfsServerPath;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 public class ClassicTfvcClient implements TfvcClient {
 
@@ -45,17 +50,43 @@ public class ClassicTfvcClient implements TfvcClient {
     @Override
     public CompletableFuture<Void> deleteFilesRecursivelyAsync(
             @NotNull ServerContext serverContext,
-            @Nullable String workingFolder,
-            @NotNull List<String> filePaths) {
-        deleteFilesRecursively(serverContext, workingFolder, filePaths);
+            @NotNull List<TfsPath> items) {
+        deleteFilesRecursively(serverContext, items);
         return CompletableFuture.completedFuture(null);
+    }
+
+    @NotNull
+    private static Optional<String> getWorkspace(TfsPath path) {
+        if (path instanceof TfsLocalPath)
+            return Optional.empty();
+        else if (path instanceof TfsServerPath)
+            return Optional.of(((TfsServerPath) path).getWorkspace());
+        else
+            throw new RuntimeException("Unknown subtype of TfsPath: " + path);
+    }
+
+    @NotNull
+    private static String getPathItem(TfsPath path) {
+        if (path instanceof TfsLocalPath)
+            return ((TfsLocalPath) path).getPath();
+        else if (path instanceof TfsServerPath)
+            return ((TfsServerPath) path).getPath();
+        else
+            throw new RuntimeException("Unknown subtype of TfsPath: " + path);
     }
 
     @Override
     public void deleteFilesRecursively(
             @NotNull ServerContext serverContext,
-            @Nullable String workingFolder,
-            @NotNull List<String> filePaths) {
-        CommandUtils.deleteFiles(serverContext, filePaths, workingFolder, true);
+            @NotNull List<TfsPath> items) {
+        Map<Optional<String>, List<TfsPath>> itemsByWorkspace = items.stream()
+                .collect(Collectors.groupingBy(ClassicTfvcClient::getWorkspace));
+        for (Map.Entry<Optional<String>, List<TfsPath>> workspaceItems : itemsByWorkspace.entrySet()) {
+            Optional<String> workspace = workspaceItems.getKey();
+            List<String> itemsInWorkspace = workspaceItems.getValue().stream()
+                    .map(ClassicTfvcClient::getPathItem)
+                    .collect(Collectors.toList());
+            CommandUtils.deleteFiles(serverContext, itemsInWorkspace, workspace.orElse(null), true);
+        }
     }
 }

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/ReactiveTfvcClient.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/ReactiveTfvcClient.java
@@ -9,8 +9,8 @@ import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.external.models.PendingChange;
 import com.microsoft.alm.plugin.external.reactive.ReactiveTfvcClientHolder;
 import com.microsoft.alm.plugin.external.reactive.ServerIdentification;
+import com.microsoft.tfs.model.connector.TfsPath;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -62,12 +62,9 @@ public class ReactiveTfvcClient implements TfvcClient {
     @Override
     public CompletableFuture<Void> deleteFilesRecursivelyAsync(
             @NotNull ServerContext serverContext,
-            @Nullable String workingFolder,
-            @NotNull List<String> filePaths) {
+            @NotNull List<TfsPath> items) {
         ServerIdentification serverIdentification = getServerIdentification(serverContext);
-        Stream<Path> paths = filePaths.stream().map(Paths::get);
-
         return ReactiveTfvcClientHolder.getInstance(myProject).getClient()
-                .thenCompose(client -> client.deleteFilesRecursivelyAsync(serverIdentification, paths));
+                .thenCompose(client -> client.deleteFilesRecursivelyAsync(serverIdentification, items));
     }
 }

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListener.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListener.java
@@ -64,7 +64,7 @@ public class TFSFileSystemListener implements LocalFileOperationsHandler, Dispos
     }
 
     @Override
-    public boolean delete(@NotNull final VirtualFile virtualFile) throws IOException {
+    public boolean delete(@NotNull final VirtualFile virtualFile) {
         long startTime = System.nanoTime();
         ourLogger.trace("Delete command started for file " + virtualFile);
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TfvcClient.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TfvcClient.java
@@ -8,8 +8,8 @@ import com.intellij.openapi.project.Project;
 import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.external.models.PendingChange;
 import com.microsoft.alm.plugin.services.PropertyService;
+import com.microsoft.tfs.model.connector.TfsPath;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -51,13 +51,11 @@ public interface TfvcClient {
     @NotNull
     CompletableFuture<Void> deleteFilesRecursivelyAsync(
             @NotNull ServerContext serverContext,
-            @Nullable String workingFolder,
-            @NotNull List<String> filePaths);
+            @NotNull List<TfsPath> items);
 
     default void deleteFilesRecursively(
             @NotNull ServerContext serverContext,
-            @Nullable String workingFolder,
-            @NotNull List<String> filePaths) throws ExecutionException, InterruptedException {
-        deleteFilesRecursivelyAsync(serverContext, workingFolder, filePaths).get();
+            @NotNull List<TfsPath> items) throws ExecutionException, InterruptedException {
+        deleteFilesRecursivelyAsync(serverContext, items).get();
     }
 }

--- a/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListenerTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListenerTest.java
@@ -19,6 +19,7 @@ import com.microsoft.alm.plugin.idea.IdeaAbstractTest;
 import com.microsoft.alm.plugin.idea.common.utils.VcsHelper;
 import com.microsoft.alm.plugin.idea.tfvc.core.tfs.TFVCUtil;
 import com.microsoft.alm.plugin.idea.tfvc.core.tfs.VersionControlPath;
+import org.jetbrains.annotations.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -383,8 +384,9 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     }
 
     @Test
-    public void testDelete_FileRename() throws Exception {
+    public void testDelete_FileRename() {
         when(mockPendingChange.getSourceItem()).thenReturn("$/server/path/to/file.txt");
+        when(mockPendingChange.getWorkspace()).thenReturn("testDelete_FileRename.workspace");
         when(mockPendingChange.isCandidate()).thenReturn(false);
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.RENAME));
         when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
@@ -393,7 +395,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
         boolean result = tfsFileSystemListener.delete(mockVirtualFile);
 
         assertTrue(result);
-        verifyDeleteCmd("$/server/path/to/file.txt");
+        verifyDeleteCmd("$/server/path/to/file.txt", "testDelete_FileRename.workspace");
     }
 
     @Test
@@ -412,8 +414,9 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     }
 
     @Test
-    public void testDelete_FileRenameEdit() throws Exception {
+    public void testDelete_FileRenameEdit() {
         when(mockPendingChange.getSourceItem()).thenReturn("$/server/path/to/file.txt");
+        when(mockPendingChange.getWorkspace()).thenReturn("testDelete_FileRenameEdit.workspace");
         when(mockPendingChange.isCandidate()).thenReturn(false);
         when(mockPendingChange.getChangeTypes()).thenReturn(ImmutableList.of(ServerStatusType.EDIT, ServerStatusType.RENAME));
         when(CommandUtils.getStatusForFiles(mockProject, mockServerContext, ImmutableList.of(CURRENT_FILE_PATH)))
@@ -423,7 +426,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
 
         assertTrue(result);
         verifyUndoCmd(CURRENT_FILE_PATH);
-        verifyDeleteCmd("$/server/path/to/file.txt");
+        verifyDeleteCmd("$/server/path/to/file.txt", "testDelete_FileRenameEdit.workspace");
     }
 
     @Test
@@ -442,9 +445,13 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     }
 
     private void verifyDeleteCmd(final String path) {
+        verifyDeleteCmd(path, null);
+    }
+
+    private void verifyDeleteCmd(final String path, @Nullable String workspace) {
         ArgumentCaptor<List> listArgumentCaptor = ArgumentCaptor.forClass(List.class);
         verifyStatic(times(1));
-        CommandUtils.deleteFiles(eq(mockServerContext), listArgumentCaptor.capture(), eq((String) null), eq(true));
+        CommandUtils.deleteFiles(eq(mockServerContext), listArgumentCaptor.capture(), eq(workspace), eq(true));
         assertEquals(1, listArgumentCaptor.getValue().size());
         assertEquals(path, listArgumentCaptor.getValue().get(0));
     }


### PR DESCRIPTION
Closes #304.

Starting from IDEA 2019.3, the file may already be deleted before IDE calls for `TFSFileSystemListener::delete`. This causes problems in our code.

To fix the issue, we'll ignore some errors from the `tf undo` command if these errors tells that there was nothing to undo (which is the case when trying to undo changes in a deleted file), and then pass the server path to the TFVC client.

It turns out that this case causes the delete command to be called with a server path, which wasn't the case in my earlier experiments. So, I had to improve the reactive client to handle the server paths (e.g. `$/Collection/Smth.java`) properly, which was a moderate challenge.