### PR TITLE
Add Settings link to the error message

### DIFF
--- a/plugin/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
+++ b/plugin/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
@@ -46,7 +46,7 @@ TFS.ServerPath.Invalid=Invalid server path detected: ''{0}''
 #Tool Exception messages
 ToolException.TF.DollarInPath=Path starts with ''$'': ''{0}''.\nTFVC client will not work properly until this file is ignored.
 ToolException.TF.HomeNotSet=The TF command line tool must be installed and the location identified in the <a href='settings'>Settings</a>.
-ToolException.TF.ExeNotFound=The specified path does not lead to a valid TF executable.
+ToolException.TF.ExeNotFound=The specified path does not lead to a valid TF executable. Visit the <a href='settings'>Settings</a> to set it up.
 ToolException.TF.BadExitCode=TF command returned non-zero exit code. Exit code = {0}
 ToolException.TF.ParseFailure=Unable to parse the output from the TF command.
 ToolException.TF.MinVersionWarning=The installed version of the TF command line is {0}. The minimum version suggested is {1}. You may run into errors or limitations with certain commands until you upgrade. Follow these <a href=https://docs.microsoft.com/en-us/azure/devops/java/intellij-faq?view=azure-devops#does-the-intellij-plug-in-support-tfvc>upgrade instructions</a>.


### PR DESCRIPTION
This is a small UX improvement for the "TF client not found" error message.