### PR TITLE
Fix TFVC collection URLs with spaces (#312)

### DIFF
--- a/L2Tests/test/com/microsoft/alm/L2/L2Test.java
+++ b/L2Tests/test/com/microsoft/alm/L2/L2Test.java
@@ -65,6 +65,7 @@ import sun.security.ssl.Debug;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -142,9 +143,11 @@ public abstract class L2Test extends UsefulTestCase {
         return authenticationInfo;
     }
 
-    public void mockRepositoryContextForProject(final String serverUri) {
+    public void mockRepositoryContextForProject(final String serverUriString) {
+        URI serverUri = URI.create(serverUriString);
         PowerMockito.mockStatic(VcsHelper.class);
-        when(VcsHelper.getRepositoryContext(any(Project.class))).thenReturn(RepositoryContext.createGitContext("/root/one", "repo1", "branch1", serverUri));
+        when(VcsHelper.getRepositoryContext(any(Project.class)))
+                .thenReturn(RepositoryContext.createGitContext("/root/one", "repo1", "branch1", serverUri));
     }
 
     private void loadContext() {

--- a/plugin/META-INF/plugin.xml
+++ b/plugin/META-INF/plugin.xml
@@ -62,10 +62,11 @@
         <li><b>Plugin is now only compatible with IntelliJ 2018.2+ (Android Studio 3.3+)</b></li>
         <li>Plugin automatically enables version control if an appropriate repository is opened (<a href="https://github.com/microsoft/azure-devops-intellij/issues/284">#284</a>)</li>
         <li>Fixed an issue with file deleting in IntelliJ 2019.3+ (<a href="https://github.com/microsoft/azure-devops-intellij/issues/304">#304</a>)</li>
-        <li><b>Enable Version Control Integration</b> now should work for Visual Studio repositories (<a href="https://github.com/microsoft/azure-devops-intellij/issues/67">#67</a>)</li>
+        <li><b>Enable Version Control Integration</b> now should work for Visual Studio workspaces (<a href="https://github.com/microsoft/azure-devops-intellij/issues/67">#67</a>)</li>
         <li>Delete operation is now much faster (<a href="https://github.com/microsoft/azure-devops-intellij/issues/296">#296</a>)</li>
         <li>Rollback operation is now much faster</li>
         <li>Undo operation now properly supports undoing files deleted through TFVC (<a href="https://github.com/microsoft/azure-devops-intellij/issues/306">#306</a>)</li>
+        <li>Fixed a bug with TFVC collection URIs that contain spaces (<a href="https://github.com/microsoft/azure-devops-intellij/issues/312">#312</a>)</li>
         <li>Small bug fixes and compatibility changes for IDEA 2020.1 (<a href="https://github.com/microsoft/azure-devops-intellij/pull/293">#293</a>)</li>
         <li>Fixed an issue with opening pull request URLs in a browser (<a href="https://github.com/microsoft/azure-devops-intellij/issues/280">#280</a>, thanks <a href="https://github.com/baltuonis">@baltuonis</a> and <a href="https://github.com/pecanw">@pecanw</a> for help)</li>
         <li>TFVC client download link is now visible when the client path is empty or the file isn't found (<a href="https://github.com/microsoft/azure-devops-intellij/pull/286">#286</a>)</li>

--- a/plugin/src/com/microsoft/alm/plugin/context/RepositoryContext.java
+++ b/plugin/src/com/microsoft/alm/plugin/context/RepositoryContext.java
@@ -3,6 +3,8 @@
 
 package com.microsoft.alm.plugin.context;
 
+import java.net.URI;
+
 public class RepositoryContext {
     public enum Type {
         GIT,
@@ -16,13 +18,13 @@ public class RepositoryContext {
     private final String teamProjectName;
 
     public static RepositoryContext createGitContext(final String localRootFolder, final String repoName,
-                                                     final String currentBranch, final String remoteUrl) {
-        return new RepositoryContext(localRootFolder, Type.GIT, repoName, currentBranch, remoteUrl, null);
+                                                     final String currentBranch, final URI remoteUrl) {
+        return new RepositoryContext(localRootFolder, Type.GIT, repoName, currentBranch, remoteUrl.toString(), null);
     }
 
     public static RepositoryContext createTfvcContext(final String localRootFolder, final String workspaceName,
-                                                      final String teamProjectName, final String serverUrl) {
-        return new RepositoryContext(localRootFolder, Type.TFVC, workspaceName, null, serverUrl, teamProjectName);
+                                                      final String teamProjectName, final URI serverUrl) {
+        return new RepositoryContext(localRootFolder, Type.TFVC, workspaceName, null, serverUrl.toString(), teamProjectName);
     }
 
     private RepositoryContext(final String localRootFolder, final Type type, final String name, final String branch,

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/FindWorkspaceCommand.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/FindWorkspaceCommand.java
@@ -4,6 +4,7 @@
 package com.microsoft.alm.plugin.external.commands;
 
 import com.microsoft.alm.common.utils.ArgumentHelper;
+import com.microsoft.alm.common.utils.UrlHelper;
 import com.microsoft.alm.plugin.authentication.AuthenticationInfo;
 import com.microsoft.alm.plugin.external.ToolRunner;
 import com.microsoft.alm.plugin.external.exceptions.ToolAuthenticationException;
@@ -65,7 +66,7 @@ public class FindWorkspaceCommand extends Command<Workspace> {
             builder.addSwitch("login", "username,pw", true);
         } else if (StringUtils.isNotEmpty(collection) && StringUtils.isNotEmpty(workspace)) {
             // need both collection and workspace name to make this call local
-            builder.addSwitch("collection", collection);
+            builder.addSwitch("collection", UrlHelper.getCmdLineFriendlyUrl(collection));
             builder.addSwitch("workspace", workspace);
         }
 

--- a/plugin/src/com/microsoft/alm/plugin/external/models/Workspace.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/models/Workspace.java
@@ -4,8 +4,10 @@
 package com.microsoft.alm.plugin.external.models;
 
 import com.google.common.base.Objects;
+import com.microsoft.alm.common.utils.UrlHelper;
 import org.apache.commons.lang.StringUtils;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -38,8 +40,16 @@ public class Workspace {
         this.location = location;
     }
 
-    public String getServer() {
+    /**
+     * @return the presentable string for server name (the URL without URL escaping applied). For example, URL
+     * "http://tfs/collection%20name" will be presented here as "http://tfs/collection name".
+     */
+    public String getServerDisplayName() {
         return server;
+    }
+
+    public URI getServerUri() {
+        return UrlHelper.createUri(server);
     }
 
     public String getName() {
@@ -89,7 +99,7 @@ public class Workspace {
         if (!StringUtils.equals(this.owner, workspace.getOwner())) {
             return false;
         }
-        if (!StringUtils.equals(this.server, workspace.getServer())) {
+        if (!StringUtils.equals(this.server, workspace.server)) {
             return false;
         }
         return true;

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/utils/VcsHelper.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/utils/VcsHelper.java
@@ -27,8 +27,10 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -163,10 +165,10 @@ public class VcsHelper {
                 final GitRepository repository = getGitRepository(project);
                 if (repository != null && TfGitHelper.isTfGitRepository(repository)) {
                     final GitRemote gitRemote = TfGitHelper.getTfGitRemote(repository);
-                    final String gitRemoteUrl = gitRemote.getFirstUrl();
+                    final String gitRemoteUrl = Objects.requireNonNull(gitRemote.getFirstUrl());
                     // TODO: Fix this HACK. There doesn't seem to be a clear way to get the full name of the current branch
                     final String branch = GIT_BRANCH_PREFIX + GitBranchUtil.getDisplayableBranchText(repository);
-                    context = RepositoryContext.createGitContext(projectRootFolder, repository.getRoot().getName(), branch, gitRemoteUrl);
+                    context = RepositoryContext.createGitContext(projectRootFolder, repository.getRoot().getName(), branch, URI.create(gitRemoteUrl));
                 }
             } else if (projectLevelVcsManager.checkVcsIsActive(TFSVcs.TFVC_NAME)) {
                 // It's TFVC so run the FindWorkspace command to get the workspace object which as the server info
@@ -175,7 +177,7 @@ public class VcsHelper {
                 if (workspace != null) {
                     final String projectName = getTeamProjectFromTfvcServerPath(
                             workspace.getMappings().size() > 0 ? workspace.getMappings().get(0).getServerPath() : null);
-                    context = RepositoryContext.createTfvcContext(projectRootFolder, workspace.getName(), projectName, workspace.getServer());
+                    context = RepositoryContext.createTfvcContext(projectRootFolder, workspace.getName(), projectName, workspace.getServerUri());
                 }
             }
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSRepositoryLocation.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSRepositoryLocation.java
@@ -51,7 +51,7 @@ public class TFSRepositoryLocation implements RepositoryLocation {
     }
 
     public String toPresentableString() {
-        return workspace.getServer();
+        return workspace.getServerDisplayName();
     }
 
     public String toString() {

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/ui/checkout/TfvcCheckoutModel.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/ui/checkout/TfvcCheckoutModel.java
@@ -141,7 +141,7 @@ public class TfvcCheckoutModel implements VcsSpecificCheckoutModel {
                     // Check the isAdvanced flag
                     if (isAdvancedChecked) {
                         // The user wants to edit the workspace before syncing...
-                        final RepositoryContext repositoryContext = RepositoryContext.createTfvcContext(localPath, workspaceName, teamProjectName, context.getServerUri().toString());
+                        final RepositoryContext repositoryContext = RepositoryContext.createTfvcContext(localPath, workspaceName, teamProjectName, context.getServerUri());
                         final WorkspaceController controller = new WorkspaceController(project, repositoryContext, context, workspaceName);
                         if (controller.showModalDialog(false)) {
                             // Save and Sync the workspace (this will be backgrounded)

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/ui/management/ManageWorkspacesModel.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/ui/management/ManageWorkspacesModel.java
@@ -132,12 +132,12 @@ public class ManageWorkspacesModel extends AbstractModel {
      */
     protected void deleteWorkspace(final Workspace selectedWorkspace) throws VcsException {
         try {
-            final Workspace workspace = getPartialWorkspace(selectedWorkspace.getServer(), selectedWorkspace.getName());
+            final Workspace workspace = getPartialWorkspace(selectedWorkspace.getServerUri().toString(), selectedWorkspace.getName());
             if (workspace != null) {
                 final String projectName = VcsHelper.getTeamProjectFromTfvcServerPath(
                         workspace.getMappings().size() > 0 ? workspace.getMappings().get(0).getServerPath() : null);
 
-                final ServerContext context = ServerContextManager.getInstance().createContextFromTfvcServerUrl(workspace.getServer(), projectName, true);
+                final ServerContext context = ServerContextManager.getInstance().createContextFromTfvcServerUrl(workspace.getServerUri().toString(), projectName, true);
                 CommandUtils.deleteWorkspace(context, selectedWorkspace.getName());
             } else {
                 logger.warn("Couldn't find partial workspace so aborting delete command");
@@ -174,14 +174,15 @@ public class ManageWorkspacesModel extends AbstractModel {
      */
     protected void editWorkspace(final Workspace selectedWorkspace, final Runnable update) throws VcsException {
         try {
-            final AuthenticationInfo authInfo = ServerContextManager.getInstance().getAuthenticationInfo(selectedWorkspace.getServer(), true);
-            final Workspace detailedWorkspace = CommandUtils.getDetailedWorkspace(selectedWorkspace.getServer(), selectedWorkspace.getName(), authInfo);
+            String serverUriString = selectedWorkspace.getServerUri().toString();
+            final AuthenticationInfo authInfo = ServerContextManager.getInstance().getAuthenticationInfo(serverUriString, true);
+            final Workspace detailedWorkspace = CommandUtils.getDetailedWorkspace(serverUriString, selectedWorkspace.getName(), authInfo);
             if (detailedWorkspace != null) {
                 final String projectName = VcsHelper.getTeamProjectFromTfvcServerPath(
                         detailedWorkspace.getMappings().size() > 0 ? detailedWorkspace.getMappings().get(0).getServerPath() : null);
-                final ServerContext context = ServerContextManager.getInstance().createContextFromTfvcServerUrl(detailedWorkspace.getServer(), projectName, true);
+                final ServerContext context = ServerContextManager.getInstance().createContextFromTfvcServerUrl(serverUriString, projectName, true);
                 // use info from the 2 incomplete workspace objects to create a complete one
-                final Workspace workspace = new Workspace(selectedWorkspace.getServer(), selectedWorkspace.getName(), selectedWorkspace.getComputer(),
+                final Workspace workspace = new Workspace(serverUriString, selectedWorkspace.getName(), selectedWorkspace.getComputer(),
                         selectedWorkspace.getOwner(), selectedWorkspace.getComment(), detailedWorkspace.getMappings(), detailedWorkspace.getLocation());
 
                 if (context == null || workspace == null) {

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/ui/workspace/WorkspaceModel.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/ui/workspace/WorkspaceModel.java
@@ -268,7 +268,7 @@ public class WorkspaceModel extends AbstractModel {
         oldWorkspace = workspace;
         if (oldWorkspace != null) {
             logger.info("loadWorkspace: got workspace, setting fields");
-            server = oldWorkspace.getServer();
+            server = oldWorkspace.getServerDisplayName();
             owner = oldWorkspace.getOwner();
             computer = oldWorkspace.getComputer();
             name = oldWorkspace.getName();

--- a/plugin/test/com/microsoft/alm/plugin/context/RepositoryContextManagerTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/context/RepositoryContextManagerTest.java
@@ -7,6 +7,8 @@ import com.microsoft.alm.plugin.AbstractTest;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.net.URI;
+
 public class RepositoryContextManagerTest extends AbstractTest {
     @Test
     public void testSingletonConstructor() {
@@ -17,7 +19,11 @@ public class RepositoryContextManagerTest extends AbstractTest {
     public void testAdd() {
         final String localRootFolder = "/path/path/";
         final RepositoryContextManager manager = new RepositoryContextManager();
-        final RepositoryContext context = RepositoryContext.createGitContext(localRootFolder, "repo1", "branch1", "url1");
+        final RepositoryContext context = RepositoryContext.createGitContext(
+                localRootFolder,
+                "repo1",
+                "branch1",
+                URI.create("http://url1"));
         Assert.assertNull(manager.get(localRootFolder));
         manager.add(context);
         Assert.assertEquals(context, manager.get(localRootFolder));
@@ -39,7 +45,11 @@ public class RepositoryContextManagerTest extends AbstractTest {
     public void testRemove() {
         final String localRootFolder = "/path/path/";
         final RepositoryContextManager manager = new RepositoryContextManager();
-        final RepositoryContext context = RepositoryContext.createGitContext(localRootFolder, "repo1", "branch1", "url1");
+        final RepositoryContext context = RepositoryContext.createGitContext(
+                localRootFolder,
+                "repo1",
+                "branch1",
+                URI.create("http://url1"));
         // Make sure remove doesn't throw if its not there
         manager.remove(localRootFolder);
 

--- a/plugin/test/com/microsoft/alm/plugin/external/commands/FindWorkspaceCommandTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/external/commands/FindWorkspaceCommandTest.java
@@ -80,7 +80,7 @@ public class FindWorkspaceCommandTest extends AbstractCommandTest {
                 "$/project1: /path";
         final Workspace workspace = cmd.parseOutput(output, "");
         Assert.assertEquals("MyWorkspace", workspace.getName());
-        Assert.assertEquals("http://server:8080/tfs/", workspace.getServer());
+        Assert.assertEquals("http://server:8080/tfs/", workspace.getServerDisplayName());
         Assert.assertEquals("", workspace.getComment());
         Assert.assertEquals("", workspace.getComputer());
         Assert.assertEquals("", workspace.getOwner());
@@ -96,7 +96,7 @@ public class FindWorkspaceCommandTest extends AbstractCommandTest {
                 "$/project1: /path";
         final Workspace workspace = cmd.parseOutput(output, "");
         Assert.assertEquals("MyWorkspace", workspace.getName());
-        Assert.assertEquals("http://server:8080/tfs/", workspace.getServer());
+        Assert.assertEquals("http://server:8080/tfs/", workspace.getServerDisplayName());
         Assert.assertEquals("", workspace.getComment());
         Assert.assertEquals("", workspace.getComputer());
         Assert.assertEquals("", workspace.getOwner());

--- a/plugin/test/com/microsoft/alm/plugin/external/commands/GetDetailedWorkspaceCommandTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/external/commands/GetDetailedWorkspaceCommandTest.java
@@ -92,7 +92,7 @@ public class GetDetailedWorkspaceCommandTest extends AbstractCommandTest  {
                 "\n";
         final Workspace workspace = cmd.parseOutput(output, "");
         Assert.assertEquals("WorkspaceName", workspace.getName());
-        Assert.assertEquals("http://organization.visualstudio.com/", workspace.getServer());
+        Assert.assertEquals("http://organization.visualstudio.com/", workspace.getServerDisplayName());
         Assert.assertEquals("Workspace created through IntelliJ", workspace.getComment());
         Assert.assertEquals("computerName", workspace.getComputer());
         Assert.assertEquals("John Smith", workspace.getOwner());

--- a/plugin/test/com/microsoft/alm/plugin/external/commands/GetWorkspaceCommandTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/external/commands/GetWorkspaceCommandTest.java
@@ -56,7 +56,7 @@ public class GetWorkspaceCommandTest extends AbstractCommandTest {
                 "</workspaces>";
         final Workspace workspace = cmd.parseOutput(output, "");
         Assert.assertEquals("workspaceName", workspace.getName());
-        Assert.assertEquals("http://server:8080/tfs/", workspace.getServer());
+        Assert.assertEquals("http://server:8080/tfs/", workspace.getServerDisplayName());
         Assert.assertEquals("description", workspace.getComment());
         Assert.assertEquals("machine", workspace.getComputer());
         Assert.assertEquals("username", workspace.getOwner());

--- a/plugin/test/com/microsoft/alm/plugin/external/models/WorkspaceTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/external/models/WorkspaceTest.java
@@ -28,7 +28,7 @@ public class WorkspaceTest extends AbstractTest {
     public void testConstructor() {
         final Workspace workspace = new Workspace(server, name, computer, owner, comment, mappings);
 
-        assertEquals(server, workspace.getServer());
+        assertEquals(server, workspace.getServerDisplayName());
         assertEquals(name, workspace.getName());
         assertEquals(computer, workspace.getComputer());
         assertEquals(owner, workspace.getOwner());

--- a/plugin/test/com/microsoft/alm/plugin/idea/common/statusBar/StatusBarManagerTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/common/statusBar/StatusBarManagerTest.java
@@ -33,6 +33,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
@@ -84,7 +85,13 @@ public class StatusBarManagerTest extends IdeaAbstractTest {
         when(projectManager.getOpenProjects()).thenReturn(new Project[]{project});
 
         PowerMockito.mockStatic(VcsHelper.class);
-        when(VcsHelper.getRepositoryContext(any(Project.class))).thenReturn(RepositoryContext.createGitContext("/root/one", "repo1", "branch1", "repoUrl1"));
+        when(VcsHelper.getRepositoryContext(any(Project.class)))
+                .thenReturn(
+                        RepositoryContext.createGitContext(
+                                "/root/one",
+                                "repo1",
+                                "branch1",
+                                URI.create("http://repoUrl1")));
 
         PowerMockito.mockStatic(GitBranchUtil.class);
         when(GitBranchUtil.getCurrentRepository(any(Project.class))).thenReturn(gitRepository);
@@ -216,7 +223,13 @@ public class StatusBarManagerTest extends IdeaAbstractTest {
     private class MyBuildStatusLookupOperation extends BuildStatusLookupOperation {
 
         protected MyBuildStatusLookupOperation() {
-            super(RepositoryContext.createGitContext("/root/one", "gitrepo", "branch", "gitRemoteUrl"), false);
+            super(
+                    RepositoryContext.createGitContext(
+                            "/root/one",
+                            "gitrepo",
+                            "branch",
+                            URI.create("http://gitRemoteUrl")),
+                    false);
         }
 
         @Override

--- a/plugin/test/com/microsoft/alm/plugin/idea/common/ui/common/tabs/TabModelImplTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/common/ui/common/tabs/TabModelImplTest.java
@@ -21,6 +21,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.net.URI;
 import java.util.Observer;
 
 import static org.mockito.Matchers.any;
@@ -94,7 +95,13 @@ public class TabModelImplTest extends IdeaAbstractTest {
 
     @Test
     public void testisTeamServicesRepository_True() {
-        when(VcsHelper.getRepositoryContext(any(Project.class))).thenReturn(RepositoryContext.createGitContext("/root/one", "repo1", "branch1", "repoUrl1"));
+        when(VcsHelper.getRepositoryContext(any(Project.class)))
+                .thenReturn(
+                        RepositoryContext.createGitContext(
+                                "/root/one",
+                                "repo1",
+                                "branch1",
+                                URI.create("http://repoUrl1")));
         Assert.assertTrue(underTest.isTeamServicesRepository());
     }
 

--- a/plugin/test/com/microsoft/alm/plugin/idea/common/ui/workitem/VcsWorkItemsModelTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/common/ui/workitem/VcsWorkItemsModelTest.java
@@ -25,6 +25,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -57,10 +58,12 @@ public class VcsWorkItemsModelTest extends IdeaAbstractTest {
     @Before
     public void setUp() {
         PowerMockito.mockStatic(VcsHelper.class);
-        when(VcsHelper.getRepositoryContext(any(Project.class))).thenReturn(RepositoryContext.createGitContext("/root/one", "repo1", "branch1", "repoUrl1"));
+        when(VcsHelper.getRepositoryContext(any(Project.class))).thenReturn(
+                RepositoryContext.createGitContext("/root/one", "repo1", "branch1", URI.create("http://repoUrl1")));
 
         model = new VcsWorkItemsModel(mockProject);
-        operation = new WorkItemLookupOperation(RepositoryContext.createGitContext("/root/one", "repo1", "branch1", "remoteURL"));
+        operation = new WorkItemLookupOperation(
+                RepositoryContext.createGitContext("/root/one", "repo1", "branch1", URI.create("http://remoteURL")));
     }
 
     @Test

--- a/plugin/test/com/microsoft/alm/plugin/idea/git/ui/pullrequest/VcsPullRequestsModelTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/git/ui/pullrequest/VcsPullRequestsModelTest.java
@@ -17,6 +17,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,7 +36,13 @@ public class VcsPullRequestsModelTest extends IdeaAbstractTest {
     @Before
     public void setUp() {
         PowerMockito.mockStatic(VcsHelper.class);
-        when(VcsHelper.getRepositoryContext(any(Project.class))).thenReturn(RepositoryContext.createGitContext("/root/one", "repo1", "branch1", "repoUrl1"));
+        when(VcsHelper.getRepositoryContext(any(Project.class)))
+                .thenReturn(
+                        RepositoryContext.createGitContext(
+                                "/root/one",
+                                "repo1",
+                                "branch1",
+                                URI.create("http://repoUrl1")));
 
         projectMock = Mockito.mock(Project.class);
     }

--- a/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/TFSCommittedChangesProviderTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/TFSCommittedChangesProviderTest.java
@@ -80,7 +80,7 @@ public class TFSCommittedChangesProviderTest extends IdeaAbstractTest {
         when(TFSVcs.getInstance(mockProject)).thenReturn(mockVcs);
         when(mockVirtualFile.getPath()).thenReturn(LOCAL_ROOT_PATH);
         when(mockRoot.getVirtualFile()).thenReturn(mockVirtualFile);
-        when(mockWorkspace.getServer()).thenReturn(SERVER_URL);
+        when(mockWorkspace.getServerDisplayName()).thenReturn(SERVER_URL);
         when(mockChangeBrowserSettings.getUserFilter()).thenReturn(USER_ME);
         when(CommandUtils.getPartialWorkspace(mockProject)).thenReturn(mockWorkspace);
         whenNew(TFSChangeListBuilder.class).withAnyArguments().thenReturn(mockTFSChangeListBuilder);

--- a/plugin/test/com/microsoft/alm/plugin/idea/tfvc/ui/management/ManageWorkspacesModelTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/tfvc/ui/management/ManageWorkspacesModelTest.java
@@ -95,7 +95,7 @@ public class ManageWorkspacesModelTest extends IdeaAbstractTest {
         workspaces = ImmutableList.of(workspace1);
         server = new Server("http://server:8080/tfs/defaultcollection", workspaces);
 
-        when(mockServerContextManager.createContextFromTfvcServerUrl(workspace1.getServer(), "root", true)).thenReturn(mockServerContext);
+        when(mockServerContextManager.createContextFromTfvcServerUrl(workspace1.getServerDisplayName(), "root", true)).thenReturn(mockServerContext);
         when(ServerContextManager.getInstance()).thenReturn(mockServerContextManager);
         when(ProgressManager.getInstance()).thenReturn(mockProgressManager);
 
@@ -253,7 +253,7 @@ public class ManageWorkspacesModelTest extends IdeaAbstractTest {
     @Test(expected = VcsException.class)
     public void testEditWorkspace_NullContext() throws Exception {
         doReturn(workspace1).when(manageWorkspacesModel).getPartialWorkspace(server.getName(), workspace1.getName());
-        when(mockServerContextManager.createContextFromTfvcServerUrl(workspace1.getServer(), "root", true)).thenReturn(null);
+        when(mockServerContextManager.createContextFromTfvcServerUrl(workspace1.getServerDisplayName(), "root", true)).thenReturn(null);
 
         manageWorkspacesModel.editWorkspace(workspace1, mockRunnable);
     }

--- a/plugin/test/com/microsoft/alm/plugin/idea/tfvc/ui/workspace/WorkspaceModelTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/tfvc/ui/workspace/WorkspaceModelTest.java
@@ -86,8 +86,8 @@ public class WorkspaceModelTest extends IdeaAbstractTest {
         when(CommandUtils.updateWorkspace(Matchers.any(ServerContext.class), Matchers.any(Workspace.class), Matchers.any(Workspace.class))).thenReturn("");
         when(CommandUtils.syncWorkspace(Matchers.any(ServerContext.class), anyString())).thenReturn(null);
 
-        repositoryContext = RepositoryContext.createTfvcContext("/path", name, "project1", server);
-        repositoryContext_noProject = RepositoryContext.createTfvcContext("/path", name, "", server);
+        repositoryContext = RepositoryContext.createTfvcContext("/path", name, "project1", workspace.getServerUri());
+        repositoryContext_noProject = RepositoryContext.createTfvcContext("/path", name, "", workspace.getServerUri());
         PowerMockito.mockStatic(VcsHelper.class);
         when(VcsHelper.getRepositoryContext(mockProject)).thenReturn(repositoryContext);
         when(VcsHelper.getRepositoryContext(mockProject2)).thenReturn(repositoryContext_noProject);
@@ -464,7 +464,7 @@ public class WorkspaceModelTest extends IdeaAbstractTest {
         when(mockWorkspace.getComputer()).thenReturn(computer);
         when(mockWorkspace.getName()).thenReturn(name);
         when(mockWorkspace.getOwner()).thenReturn(owner);
-        when(mockWorkspace.getServer()).thenReturn(server);
+        when(mockWorkspace.getServerDisplayName()).thenReturn(server);
         when(mockWorkspace.getMappings()).thenReturn(mappings);
         when(mockWorkspace.getLocation()).thenReturn(Workspace.Location.SERVER);
 

--- a/plugin/test/com/microsoft/alm/plugin/operations/BuildStatusLookupOperationTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/operations/BuildStatusLookupOperationTest.java
@@ -83,7 +83,12 @@ public class BuildStatusLookupOperationTest extends AbstractTest {
     @Test
     public void testConstructor_goodInputs() {
         BuildStatusLookupOperation operation1 = new BuildStatusLookupOperation(
-                RepositoryContext.createGitContext("/root/one", "repoName", "branch", "url"), false);
+                RepositoryContext.createGitContext(
+                        "/root/one",
+                        "repoName",
+                        "branch",
+                        URI.create("http://url")),
+                false);
     }
 
     @Test
@@ -283,7 +288,11 @@ public class BuildStatusLookupOperationTest extends AbstractTest {
         }
 
         public RepositoryContext getRepositoryContext() {
-            return RepositoryContext.createGitContext("/root/one", currentRepo.getName(), currentBranch, currentRepo.getRemoteUrl());
+            return RepositoryContext.createGitContext(
+                    "/root/one",
+                    currentRepo.getName(),
+                    currentBranch,
+                    URI.create(currentRepo.getRemoteUrl()));
         }
     }
 

--- a/plugin/test/com/microsoft/alm/plugin/operations/WorkItemLookupOperationTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/operations/WorkItemLookupOperationTest.java
@@ -26,6 +26,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -86,7 +87,7 @@ public class WorkItemLookupOperationTest extends AbstractTest {
         }
 
         //construct correctly
-        WorkItemLookupOperation operation1 = new WorkItemLookupOperation(RepositoryContext.createGitContext("/root/one", "repo1", "branch1", "gitRemoteUrl"));
+        WorkItemLookupOperation operation1 = new WorkItemLookupOperation(RepositoryContext.createGitContext("/root/one", "repo1", "branch1", URI.create("gitRemoteUrl")));
     }
 
     @Test
@@ -98,7 +99,7 @@ public class WorkItemLookupOperationTest extends AbstractTest {
         workItems.add(item);
         setupLocalTests(workItems);
 
-        WorkItemLookupOperation operation = new WorkItemLookupOperation(RepositoryContext.createGitContext("/root/one", "repo1", "branch1", "gitRemoteUrl"));
+        WorkItemLookupOperation operation = new WorkItemLookupOperation(RepositoryContext.createGitContext("/root/one", "repo1", "branch1", URI.create("gitRemoteUrl")));
         final SettableFuture<Boolean> startedCalled = SettableFuture.create();
         final SettableFuture<Boolean> completedCalled = SettableFuture.create();
         final SettableFuture<WorkItemLookupOperation.WitResults> witResults = SettableFuture.create();
@@ -134,7 +135,7 @@ public class WorkItemLookupOperationTest extends AbstractTest {
     public void testDoWork_failure() throws InterruptedException, ExecutionException, TimeoutException {
         setupLocalTests(null);
 
-        WorkItemLookupOperation operation = new WorkItemLookupOperation(RepositoryContext.createGitContext("/root/one", "repo1", "branch1", "gitRemoteUrl"));
+        WorkItemLookupOperation operation = new WorkItemLookupOperation(RepositoryContext.createGitContext("/root/one", "repo1", "branch1", URI.create("gitRemoteUrl")));
         final SettableFuture<Boolean> startedCalled = SettableFuture.create();
         final SettableFuture<Boolean> completedCalled = SettableFuture.create();
         final SettableFuture<WorkItemLookupOperation.WitResults> witResults = SettableFuture.create();

--- a/plugin/test/com/microsoft/alm/plugin/operations/WorkItemQueriesLookupOperationTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/operations/WorkItemQueriesLookupOperationTest.java
@@ -26,6 +26,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -43,7 +44,11 @@ import static org.mockito.Mockito.when;
 public class WorkItemQueriesLookupOperationTest extends AbstractTest {
     private ServerContextManager serverContextManager;
     private RepositoryContext defaultRepositoryContext =
-            RepositoryContext.createGitContext("/root/one", "repo1", "branch1", "http://one.vs.com/_git/repo1");
+            RepositoryContext.createGitContext(
+                    "/root/one",
+                    "repo1",
+                    "branch1",
+                    URI.create("http://one.vs.com/_git/repo1"));
 
     private void setupLocalTests(List<QueryHierarchyItem> queries) {
         MockitoAnnotations.initMocks(this);


### PR DESCRIPTION
Closes #312.

This fixes the `Workspace` API (we'll have two distinct methods to get either presentable string or a real URI) and some other APIs that were accepting URIs as strings, so it'll be harder to break them in future.

The issue is originating from the strange design decision of TFVC client: it really unescapes URIs before presenting them to the callers for some reason, so we'll have to work around it in our plugin code.