### PR TITLE
Update the plugin vendor URL

### DIFF
--- a/plugin/META-INF/plugin.xml
+++ b/plugin/META-INF/plugin.xml
@@ -8,7 +8,7 @@
     <name>Azure DevOps</name>
     <!-- <version>1.155.0</version> NOTE: Version is set automatically on build, update it in gradle.properties -->
     <category>VCS Integration</category>
-    <vendor url="https://azure.microsoft.com/en-us/services/devops/">Microsoft Corporation</vendor>
+    <vendor url="https://github.com/microsoft/azure-devops-intellij">Microsoft Corporation</vendor>
     <description><![CDATA[
     <br />
       Azure DevOps is a plugin to enable working with Git and TFVC repositories on Azure DevOps Services or Team Foundation Server (TFS) 2015+.


### PR DESCRIPTION
Users are sometimes confused by the current URL, since it has no clues where do they report issues they encounter during usage of this plugin.

To make the issue reporting easier for our end users, we've decided to update the vendor URL to direct them over to this repository.

This link is mostly visible during the exception reporting in IDE, in this window:
![image](https://user-images.githubusercontent.com/92793/77292705-65ec1b80-6d13-11ea-9249-280415e15df2.png)
