### PR TITLE
Faster TFVC history

### DIFF
--- a/client/backend/src/main/kotlin/com/microsoft/tfs/DataConversion.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/DataConversion.kt
@@ -3,12 +3,11 @@
 
 package com.microsoft.tfs
 
+import com.microsoft.tfs.core.clients.versioncontrol.VersionControlConstants
 import com.microsoft.tfs.core.clients.versioncontrol.path.LocalPath
-import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.ChangeType
-import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.PendingChange
-import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.PendingSet
-import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.RecursionType
+import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.*
 import com.microsoft.tfs.core.clients.versioncontrol.specs.ItemSpec
+import com.microsoft.tfs.core.util.FileEncoding
 import com.microsoft.tfs.model.host.*
 import java.text.SimpleDateFormat
 
@@ -59,3 +58,66 @@ fun TfsPath.toCanonicalPathString(): String = when(this) {
 
 fun TfsPath.toCanonicalPathItemSpec(recursionType: RecursionType): ItemSpec =
     ItemSpec(toCanonicalPathString(), recursionType)
+
+/**
+ * Converts a pair of [Item] and [ExtendedItem] to [TfsItemInfo]. Tries to replicate behavior of
+ * `com.microsoft.tfs.client.clc.vc.commands.CommandProperties.ItemProperties::setExtendedItem` from the TFS
+ * command-line client.
+ */
+fun toTfsItemInfo(item: Item?, extendedItem: ExtendedItem?): TfsItemInfo {
+    if (item == null && extendedItem == null) {
+        throw Exception("Bot item and extendedItem should never be null")
+    }
+
+    var serverItem = item?.serverItem
+    var localItem: String? = null
+    var localVersion = 0
+    val serverVersion = item?.changeSetID ?: 0
+    var change: String? = null
+    var itemTypeName: String? = null
+    var lockStatus: String? = null
+    var lockOwner: String? = null
+    val deletionId = item?.deletionID ?: 0
+    val checkInDate = item?.checkinDate?.time?.let(isoDateFormat::format)
+    var type = item?.itemType
+    val encodingName = if (item?.encoding == FileEncoding(VersionControlConstants.ENCODING_UNCHANGED))
+        null
+    else
+        item?.encoding?.name
+    val fileSize = item?.contentLength
+
+    if (extendedItem != null) {
+        // Only show the server item when the user has the file or has a pending change on the file.
+        if (extendedItem.localItem != null || extendedItem.pendingChange != ChangeType.NONE) {
+            serverItem = extendedItem.targetServerItem
+            localItem = extendedItem.localItem
+            localVersion = extendedItem.localVersion
+            itemTypeName = extendedItem.itemType.toUIString()
+        }
+
+        change =
+            if (extendedItem.pendingChange == ChangeType.NONE) "none"
+            else extendedItem.pendingChange.toUIString(false, extendedItem)
+
+        lockStatus = extendedItem.lockLevel.toUIString()
+        lockOwner = extendedItem.lockOwner
+        type = extendedItem.itemType
+    }
+
+    val fileEncodingName = if (type == ItemType.FILE) encodingName else null
+
+    return TfsItemInfo(
+        serverItem,
+        localItem,
+        localVersion,
+        serverVersion,
+        change,
+        itemTypeName,
+        lockStatus,
+        lockOwner,
+        deletionId,
+        checkInDate,
+        fileEncodingName,
+        fileSize
+    )
+}

--- a/client/backend/src/main/kotlin/com/microsoft/tfs/Main.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/Main.kt
@@ -14,6 +14,7 @@ import com.microsoft.tfs.core.httpclient.UsernamePasswordCredentials
 import com.microsoft.tfs.model.host.*
 import org.apache.log4j.Level
 import java.nio.file.Paths
+import java.util.*
 import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {
@@ -39,6 +40,7 @@ private fun printUsage() {
 }
 
 private fun initializeApp(args: Array<String>) {
+    Locale.setDefault(Locale.US)
     val logDirectory = if (args.size > 1) Paths.get(args[1]) else null
     val logLevel = if (args.size > 2) Level.toLevel(args[2]) else Level.INFO
     Logging.initialize(logDirectory, logLevel)

--- a/client/backend/src/main/kotlin/com/microsoft/tfs/Main.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/Main.kt
@@ -102,11 +102,11 @@ private fun initializeCollection(lifetime: Lifetime, definition: TfsCollectionDe
         logger.info { "Performing $title operation on ${paths.size} paths, first 10: ${paths.take(10).joinToString()}" }
     }
 
-    collection.getItemsInfo.set { paths ->
+    collection.getLocalItemsInfo.set { paths ->
         if (paths.isEmpty()) return@set emptyList()
 
-        logPaths("Get Info", paths)
-        client.getItemsInfo(paths)
+        logPaths("Get Local Items Info", paths)
+        client.getLocalItemsInfo(paths)
     }
 
     collection.invalidatePaths.set { paths ->

--- a/client/backend/src/main/kotlin/com/microsoft/tfs/Main.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/Main.kt
@@ -102,6 +102,13 @@ private fun initializeCollection(lifetime: Lifetime, definition: TfsCollectionDe
         logger.info { "Performing $title operation on ${paths.size} paths, first 10: ${paths.take(10).joinToString()}" }
     }
 
+    collection.getItemsInfo.set { paths ->
+        if (paths.isEmpty()) return@set emptyList()
+
+        logPaths("Get Info", paths)
+        client.getItemsInfo(paths)
+    }
+
     collection.invalidatePaths.set { paths ->
         if (paths.isEmpty()) return@set
 

--- a/client/backend/src/main/kotlin/com/microsoft/tfs/TfsClient.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/TfsClient.kt
@@ -16,7 +16,6 @@ import com.microsoft.tfs.core.clients.versioncontrol.VersionControlClient
 import com.microsoft.tfs.core.clients.versioncontrol.events.UndonePendingChangeListener
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.*
 import com.microsoft.tfs.core.clients.versioncontrol.specs.ItemSpec
-import com.microsoft.tfs.core.clients.versioncontrol.specs.version.LatestVersionSpec
 import com.microsoft.tfs.core.httpclient.Credentials
 import com.microsoft.tfs.model.host.TfsItemInfo
 import com.microsoft.tfs.model.host.TfsLocalPath
@@ -84,30 +83,17 @@ class TfsClient(lifetime: Lifetime, serverUri: URI, credentials: Credentials) {
         return results
     }
 
-    fun getItemsInfo(paths: List<TfsLocalPath>): List<TfsItemInfo> {
+    fun getLocalItemsInfo(paths: List<TfsLocalPath>): List<TfsItemInfo> {
         val infos = ArrayList<TfsItemInfo>(paths.size)
         enumeratePathsWithWorkspace(paths) { workspace, workspacePaths ->
             val downloadType = if (workspace.isLocal) GetItemsOptions.LOCAL_ONLY else GetItemsOptions.NONE
             val itemSpecs = workspacePaths.mapToArray { it.toCanonicalPathItemSpec(RecursionType.NONE) }
-            val itemSets = client.getItems(
-                itemSpecs,
-                LatestVersionSpec.INSTANCE,
-                DeletedState.ANY,
-                ItemType.ANY,
-                downloadType
-            )
-            val items = itemSets.asSequence().flatMap { it.items.asSequence() }.map { it.itemID to it }.toMap()
             val extendedItems = workspace.getExtendedItems(itemSpecs, DeletedState.ANY, ItemType.ANY, downloadType)
                 .asSequence()
                 .flatMap { it.asSequence() }
-                .map { it.itemID to it }
-                .toMap()
 
-            val keySet = items.keys + extendedItems.keys
-            for (itemId in keySet) {
-                val item = items[itemId]
-                val extendedItem = extendedItems[itemId]
-                infos.add(toTfsItemInfo(item, extendedItem))
+            for (extendedItem in extendedItems) {
+                infos.add(extendedItem.toTfsItemInfo())
             }
         }
 

--- a/client/connector/src/main/kotlin/com/microsoft/tfs/connector/ReactiveClientConnection.kt
+++ b/client/connector/src/main/kotlin/com/microsoft/tfs/connector/ReactiveClientConnection.kt
@@ -68,9 +68,12 @@ class ReactiveClientConnection(private val scheduler: IScheduler) {
             collection.getPendingChanges.start(paths).pipeTo(lt, this)
         }
 
-    fun getItemsInfoAsync(collection: TfsCollection, paths: List<TfsLocalPath>): CompletionStage<List<TfsItemInfo>> =
+    fun getLocalItemsInfoAsync(
+        collection: TfsCollection,
+        paths: List<TfsLocalPath>
+    ): CompletionStage<List<TfsItemInfo>> =
         queueFutureAsync { lt ->
-            collection.getItemsInfo.start(paths).pipeTo(lt, this)
+            collection.getLocalItemsInfo.start(paths).pipeTo(lt, this)
         }
 
     fun invalidatePathsAsync(collection: TfsCollection, paths: List<TfsLocalPath>): CompletionStage<Void> =

--- a/client/connector/src/main/kotlin/com/microsoft/tfs/connector/ReactiveClientConnection.kt
+++ b/client/connector/src/main/kotlin/com/microsoft/tfs/connector/ReactiveClientConnection.kt
@@ -68,6 +68,11 @@ class ReactiveClientConnection(private val scheduler: IScheduler) {
             collection.getPendingChanges.start(paths).pipeTo(lt, this)
         }
 
+    fun getItemsInfoAsync(collection: TfsCollection, paths: List<TfsLocalPath>): CompletionStage<List<TfsItemInfo>> =
+        queueFutureAsync { lt ->
+            collection.getItemsInfo.start(paths).pipeTo(lt, this)
+        }
+
     fun invalidatePathsAsync(collection: TfsCollection, paths: List<TfsLocalPath>): CompletionStage<Void> =
         queueFutureAsync { lt ->
             collection.invalidatePaths.start(paths).pipeToVoid(lt, this)

--- a/client/protocol/src/main/kotlin/model/tfs/TfsModel.kt
+++ b/client/protocol/src/main/kotlin/model/tfs/TfsModel.kt
@@ -67,7 +67,6 @@ object TfsModel : Root() {
         field("deletionId", int)
         field("lastModified", string.nullable)
         field("fileEncoding", string.nullable)
-        field("fileSize", long.nullable)
     }
 
     private val TfsCollection = classdef {
@@ -80,8 +79,8 @@ object TfsModel : Root() {
         call("getPendingChanges", immutableList(TfsPath), immutableList(TfsPendingChange))
             .doc("Determines a set of the pending changes in the collection")
 
-        call("getItemsInfo", immutableList(TfsLocalPath), immutableList(TfsItemInfo))
-            .doc("Provides information on repository items")
+        call("getLocalItemsInfo", immutableList(TfsLocalPath), immutableList(TfsItemInfo))
+            .doc("Provides information on local repository items")
 
         call("invalidatePaths", immutableList(TfsLocalPath), void)
             .doc("Invalidates the paths in the TFS cache")

--- a/client/protocol/src/main/kotlin/model/tfs/TfsModel.kt
+++ b/client/protocol/src/main/kotlin/model/tfs/TfsModel.kt
@@ -55,6 +55,21 @@ object TfsModel : Root() {
         field("credentials", TfsCredentials)
     }
 
+    private val TfsItemInfo = structdef {
+        field("serverItem", string.nullable)
+        field("localItem", string.nullable)
+        field("localVersion", int)
+        field("serverVersion", int)
+        field("change", string.nullable)
+        field("type", string.nullable)
+        field("lock", string.nullable)
+        field("lockOwner", string.nullable)
+        field("deletionId", int)
+        field("lastModified", string.nullable)
+        field("fileEncoding", string.nullable)
+        field("fileSize", long.nullable)
+    }
+
     private val TfsCollection = classdef {
         property("isReady", bool)
             .doc("Whether the client is ready to accept method calls")
@@ -64,6 +79,9 @@ object TfsModel : Root() {
 
         call("getPendingChanges", immutableList(TfsPath), immutableList(TfsPendingChange))
             .doc("Determines a set of the pending changes in the collection")
+
+        call("getItemsInfo", immutableList(TfsLocalPath), immutableList(TfsItemInfo))
+            .doc("Provides information on repository items")
 
         call("invalidatePaths", immutableList(TfsLocalPath), void)
             .doc("Invalidates the paths in the TFS cache")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-buildNumber=1.159.0
+buildNumber=1.160.0
 ideaVersion=2018.2
 
 kotlin.code.style=official

--- a/plugin/resources/META-INF/plugin.xml
+++ b/plugin/resources/META-INF/plugin.xml
@@ -59,17 +59,7 @@
     <change-notes><![CDATA[
       <br />
       <ul>
-        <li><b>Plugin is now only compatible with IntelliJ 2018.2+ (Android Studio 3.3+)</b></li>
-        <li>Plugin automatically enables version control if an appropriate repository is opened (<a href="https://github.com/microsoft/azure-devops-intellij/issues/284">#284</a>)</li>
-        <li>Fixed an issue with file deleting in IntelliJ 2019.3+ (<a href="https://github.com/microsoft/azure-devops-intellij/issues/304">#304</a>)</li>
-        <li><b>Enable Version Control Integration</b> now should work for Visual Studio workspaces (<a href="https://github.com/microsoft/azure-devops-intellij/issues/67">#67</a>)</li>
-        <li>Delete operation is now much faster (<a href="https://github.com/microsoft/azure-devops-intellij/issues/296">#296</a>)</li>
-        <li>Rollback operation is now much faster</li>
-        <li>Undo operation now properly supports undoing files deleted through TFVC (<a href="https://github.com/microsoft/azure-devops-intellij/issues/306">#306</a>)</li>
-        <li>Fixed a bug with TFVC collection URIs that contain spaces (<a href="https://github.com/microsoft/azure-devops-intellij/issues/312">#312</a>)</li>
-        <li>Small bug fixes and compatibility changes for IDEA 2020.1 (<a href="https://github.com/microsoft/azure-devops-intellij/pull/293">#293</a>)</li>
-        <li>Fixed an issue with opening pull request URLs in a browser (<a href="https://github.com/microsoft/azure-devops-intellij/issues/280">#280</a>, thanks <a href="https://github.com/baltuonis">@baltuonis</a> and <a href="https://github.com/pecanw">@pecanw</a> for help)</li>
-        <li>TFVC client download link is now visible when the client path is empty or the file isn't found (<a href="https://github.com/microsoft/azure-devops-intellij/pull/286">#286</a>)</li>
+        <li>Repository history refresh has been made significantly faster when Reactive client is enabled</li>
       </ul>
       <br />
     ]]>

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/InfoCommand.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/InfoCommand.java
@@ -112,8 +112,7 @@ public class InfoCommand extends Command<List<ItemInfo>> {
                 propertyMap.get("server lock owner"),
                 propertyMap.get("server deletion id"),
                 propertyMap.get("server last modified"),
-                propertyMap.get("server file type"),
-                propertyMap.get("server size")
+                propertyMap.get("server file type")
         );
     }
 }

--- a/plugin/src/com/microsoft/alm/plugin/external/models/ItemInfo.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/models/ItemInfo.java
@@ -4,6 +4,7 @@
 package com.microsoft.alm.plugin.external.models;
 
 import com.microsoft.alm.common.utils.SystemHelper;
+import com.microsoft.tfs.model.connector.TfsItemInfo;
 import org.apache.commons.lang.StringUtils;
 
 /**
@@ -38,6 +39,22 @@ public class ItemInfo {
         this.lastModified = lastModified;
         this.fileType = fileType;
         this.fileSize = fileSize;
+    }
+
+    public static ItemInfo from(TfsItemInfo ii) {
+        return new ItemInfo(
+                ii.getServerItem(),
+                ii.getLocalItem(),
+                Integer.toString(ii.getServerVersion()),
+                Integer.toString(ii.getLocalVersion()),
+                ii.getChange(),
+                ii.getType(),
+                ii.getLock(),
+                ii.getLockOwner(),
+                Integer.toString(ii.getDeletionId()),
+                ii.getLastModified(),
+                ii.getFileEncoding(),
+                ii.getFileSize() == null ? null : Long.toString(ii.getFileSize()));
     }
 
     public String getServerItem() {

--- a/plugin/src/com/microsoft/alm/plugin/external/models/ItemInfo.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/models/ItemInfo.java
@@ -22,11 +22,10 @@ public class ItemInfo {
     private final String deletionId;
     private final String lastModified;
     private final String fileType;
-    private final String fileSize;
 
     public ItemInfo(final String serverItem, final String localItem, final String serverVersion, final String localVersion,
                     final String change, final String type, final String lock, final String lockOwner, final String deletionId,
-                    final String lastModified, final String fileType, final String fileSize) {
+                    final String lastModified, final String fileType) {
         this.serverItem = serverItem;
         this.localItem = localItem;
         this.serverVersion = serverVersion;
@@ -38,7 +37,6 @@ public class ItemInfo {
         this.deletionId = deletionId;
         this.lastModified = lastModified;
         this.fileType = fileType;
-        this.fileSize = fileSize;
     }
 
     public static ItemInfo from(TfsItemInfo ii) {
@@ -53,8 +51,7 @@ public class ItemInfo {
                 ii.getLockOwner(),
                 Integer.toString(ii.getDeletionId()),
                 ii.getLastModified(),
-                ii.getFileEncoding(),
-                ii.getFileSize() == null ? null : Long.toString(ii.getFileSize()));
+                ii.getFileEncoding());
     }
 
     public String getServerItem() {
@@ -111,9 +108,5 @@ public class ItemInfo {
 
     public boolean isFolder() {
         return !StringUtils.equalsIgnoreCase(type, "file");
-    }
-
-    public String getFileSize() {
-        return fileSize;
     }
 }

--- a/plugin/src/com/microsoft/alm/plugin/external/models/PendingChange.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/models/PendingChange.java
@@ -3,9 +3,11 @@
 
 package com.microsoft.alm.plugin.external.models;
 
+import com.microsoft.tfs.model.connector.TfsPendingChange;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * This class represents the data returned by the TF command line about a pending change.
@@ -68,6 +70,21 @@ public class PendingChange {
         this.computer = computer;
         this.isCandidate = isCandidate;
         this.sourceItem = sourceItem;
+    }
+
+    public static PendingChange from(TfsPendingChange pc) {
+        return new PendingChange(
+                pc.getServerItem(),
+                pc.getLocalItem(),
+                Integer.toString(pc.getVersion()),
+                pc.getOwner(),
+                pc.getDate(),
+                pc.getLock(),
+                pc.getChangeTypes().stream().map(ServerStatusType::from).collect(Collectors.toList()),
+                pc.getWorkspace(),
+                pc.getComputer(),
+                pc.isCandidate(),
+                pc.getSourceItem());
     }
 
     public String getComputer() {

--- a/plugin/src/com/microsoft/alm/plugin/external/utils/CommandUtils.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/utils/CommandUtils.java
@@ -603,9 +603,8 @@ public class CommandUtils {
      * Returns the item infos for the item paths provided. Specify a working folder in the workspace if you want info for
      * server paths.
      */
-    public static List<ItemInfo> getItemInfos(final ServerContext context, final String workingFolder,
-                                              final List<String> itemPaths) {
-        final Command<List<ItemInfo>> infoCommand = new InfoCommand(context, workingFolder, itemPaths);
+    public static List<ItemInfo> getItemInfos(final ServerContext context, final List<String> itemPaths) {
+        final Command<List<ItemInfo>> infoCommand = new InfoCommand(context, itemPaths);
         return infoCommand.runSynchronously();
     }
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/MultipleItemAction.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/MultipleItemAction.java
@@ -37,9 +37,9 @@ import com.intellij.vcsUtil.VcsUtil;
 import com.microsoft.alm.helpers.Path;
 import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.external.models.ItemInfo;
-import com.microsoft.alm.plugin.external.utils.CommandUtils;
 import com.microsoft.alm.plugin.idea.common.resources.TfPluginBundle;
 import com.microsoft.alm.plugin.idea.tfvc.core.TFSVcs;
+import com.microsoft.alm.plugin.idea.tfvc.core.TfvcClient;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,8 +97,8 @@ public abstract class MultipleItemAction extends DumbAwareAction {
                 }
 
                 // Get the item infos (no need for a working folder since these are local paths)
-                final List<ItemInfo> infos = CommandUtils.getItemInfos(context.serverContext, null, localPaths);
-                context.itemInfos.addAll(infos);
+                TfvcClient client = TfvcClient.getInstance(context.project);
+                client.getLocalItemsInfo(context.serverContext, localPaths, context.itemInfos::add);
 
                 // Set the default path and additional parameters
                 if (context.itemInfos.size() > 0) {

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/ClassicTfvcClient.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/ClassicTfvcClient.java
@@ -5,6 +5,7 @@ package com.microsoft.alm.plugin.idea.tfvc.core;
 
 import com.intellij.openapi.project.Project;
 import com.microsoft.alm.plugin.context.ServerContext;
+import com.microsoft.alm.plugin.external.models.ItemInfo;
 import com.microsoft.alm.plugin.external.models.PendingChange;
 import com.microsoft.alm.plugin.external.utils.CommandUtils;
 import com.microsoft.alm.plugin.idea.tfvc.ui.settings.EULADialog;
@@ -18,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class ClassicTfvcClient implements TfvcClient {
@@ -45,6 +47,25 @@ public class ClassicTfvcClient implements TfvcClient {
         return EULADialog.executeWithGuard(
                 myProject,
                 () -> CommandUtils.getStatusForFiles(myProject, serverContext, pathsToProcess));
+    }
+
+    @NotNull
+    @Override
+    public CompletionStage<Void> getLocalItemsInfoAsync(
+            @NotNull ServerContext serverContext,
+            @NotNull List<String> pathsToProcess,
+            @NotNull Consumer<ItemInfo> onItemReceived) {
+        getLocalItemsInfo(serverContext, pathsToProcess, onItemReceived);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void getLocalItemsInfo(
+            @NotNull ServerContext serverContext,
+            @NotNull List<String> pathsToProcess,
+            @NotNull Consumer<ItemInfo> onItemReceived) {
+        List<ItemInfo> itemInfos = CommandUtils.getItemInfos(serverContext, pathsToProcess);
+        itemInfos.forEach(onItemReceived);
     }
 
     @NotNull

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/ReactiveTfvcClient.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/ReactiveTfvcClient.java
@@ -6,6 +6,7 @@ package com.microsoft.alm.plugin.idea.tfvc.core;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.microsoft.alm.plugin.context.ServerContext;
+import com.microsoft.alm.plugin.external.models.ItemInfo;
 import com.microsoft.alm.plugin.external.models.PendingChange;
 import com.microsoft.alm.plugin.external.reactive.ReactiveTfvcClientHolder;
 import com.microsoft.alm.plugin.external.reactive.ServerIdentification;
@@ -17,6 +18,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -63,6 +65,20 @@ public class ReactiveTfvcClient implements TfvcClient {
 
             return ReactiveTfvcClientHolder.getInstance(myProject).getClient()
                     .thenCompose(client -> client.getPendingChangesAsync(serverIdentification, paths));
+        });
+    }
+
+    @NotNull
+    @Override
+    public CompletionStage<Void> getLocalItemsInfoAsync(
+            @NotNull ServerContext serverContext,
+            @NotNull List<String> pathsToProcess,
+            @NotNull Consumer<ItemInfo> onItemReceived) {
+        return traceTime("Info", () -> {
+            ServerIdentification serverIdentification = getServerIdentification(serverContext);
+            Stream<Path> paths = pathsToProcess.stream().map(Paths::get);
+            return ReactiveTfvcClientHolder.getInstance(myProject).getClient()
+                    .thenCompose(client -> client.getItemsInfoAsync(serverIdentification, paths, onItemReceived));
         });
     }
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/ReactiveTfvcClient.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/ReactiveTfvcClient.java
@@ -78,7 +78,7 @@ public class ReactiveTfvcClient implements TfvcClient {
             ServerIdentification serverIdentification = getServerIdentification(serverContext);
             Stream<Path> paths = pathsToProcess.stream().map(Paths::get);
             return ReactiveTfvcClientHolder.getInstance(myProject).getClient()
-                    .thenCompose(client -> client.getItemsInfoAsync(serverIdentification, paths, onItemReceived));
+                    .thenCompose(client -> client.getLocalItemsInfoAsync(serverIdentification, paths, onItemReceived));
         });
     }
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSDiffProvider.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSDiffProvider.java
@@ -130,19 +130,19 @@ public class TFSDiffProvider extends DiffProviderEx {
             filePaths.add(filePath);
         }
 
-        final Map<VirtualFile, VcsRevisionNumber> revisionMap = ContainerUtil.newHashMap();
-        final List<ItemInfo> statusList = CommandUtils.getItemInfos(context, null, filePaths);
+        TfvcClient client = TfvcClient.getInstance(project);
         final LocalFileSystem fs = LocalFileSystem.getInstance();
-        for (ItemInfo info : statusList) {
+        final Map<VirtualFile, VcsRevisionNumber> revisionMap = ContainerUtil.newHashMap();
+        client.getLocalItemsInfo(context, filePaths, info -> {
             final String itemPath = info.getLocalItem();
             final VirtualFile virtualFile = fs.findFileByPath(itemPath);
             if (virtualFile == null) {
                 logger.error("VirtualFile not found for item " + itemPath);
-                continue;
+                return;
             }
 
             revisionMap.put(virtualFile, createRevision(info, itemPath));
-        }
+        });
 
         return revisionMap;
     }


### PR DESCRIPTION
This PR significantly improves the speed of TFVC history refresh in case when Reactive client is enabled.

Each time the user updates the repository history, IntelliJ's VCS provider updates its internal file revision cache, to know which files have been updated on server but not yet updated on the client. This operation leads to `tf info` call that, in turn, asks TFS server for information on every file in a separate HTTP call.

Not only TFS client is written in a very inefficient way regarding the information requests, but it is absolutely unnecessary, since we have all the information available locally and don't ever need to get to the server (in case of local workspace; I've also included rudimentary server workspace support for this feature even if we don't allow them for now).

For my big repository (with about 5000 files), this changes the history refresh time significantly: from ≈25 minutes to ≈6 seconds (and all the time is eaten by `tf history`, and not the `tf info`; `tf info` itself is blazingly fast now).