### PR TITLE
Update the documentation and pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Once you've downloaded the dependencies, run the build by:
 5. Create a "Plugin" configuration to run/debug the code.
    * Run -> Edit Configurations... -> Add -> Gradle 
    * Provide a name for the configuration (e.g., IntelliJ for TFS)
-   * Set Gradle project to `plugin`
-   * Set Tasks to `runIde`
+   * Set Gradle project to `azure-devops-intellij`
+   * Set Tasks to `:plugin:runIde`
 
 6. Run the plugin by selecting Run -> Run <configuration you used above>.
 

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -42,14 +42,14 @@ jobs:
         condition: always()
         inputs:
           path: 'plugin/build/reports'
-          artifact: '$(build.buildNumber).$(Agent.OS)-test-reports'
+          artifact: '$(System.JobId).$(build.buildNumber).$(Agent.OS)-test-reports'
 
       - task: PublishPipelineArtifact@1
         displayName: "Publish Artifact: $(build.buildNumber)"
         condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['Agent.OS'], 'Linux'))
         inputs:
           path: 'plugin/build/distributions'
-          artifact: '$(build.buildNumber)'
+          artifact: '$(System.JobId).$(build.buildNumber)'
 
       - task: Cache@2
         inputs:
@@ -94,14 +94,14 @@ jobs:
         condition: eq(variables['System.PullRequest.IsFork'], false)
         inputs:
           path: 'L2Tests/build/reports'
-          artifact: '$(build.buildNumber).$(Agent.OS)-integration-test-reports'
+          artifact: '$(System.JobId).$(build.buildNumber).$(Agent.OS)-integration-test-reports'
 
       - task: PublishPipelineArtifact@1
         displayName: "Publish integration test logs"
         condition: eq(variables['System.PullRequest.IsFork'], false)
         inputs:
           path: 'L2Tests/build/idea-sandbox/system-test/testlog'
-          artifact: '$(build.buildNumber).$(Agent.OS)-integration-test-logs'
+          artifact: '$(System.JobId).$(build.buildNumber).$(Agent.OS)-integration-test-logs'
 
   - job: test_build # check compilation for newest IDEA
     pool:


### PR DESCRIPTION
Now we have a task `:plugin:test-utils:runIde` that will be triggered by the older IDE setup, so the run instructions have to be updated.

I've also found that our jobs cannot overwrite already published test reports on rerun, so we'll have to make adjustments to fix it.