### PR TITLE
Delete ignored files

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Those settings are already configured in the `com.microsoft.alm.plugin.idea.iml`
 
 Gradle build will fail if checkstyle plugin detects a violation.
 
-## Running Integration Tests (L2 tests)
+## Running Integration Tests (L2 tests and reactive client tests)
 
 Our Integration tests are in the L2Tests folder. In order to run them correctly, you have to set up the environment and have an Azure DevOps Services organization setup to run against.
 
@@ -109,6 +109,8 @@ Here are the steps to setup your environment:
 3. Other things to note:
    * You can toggle whether the tests will run or not simply by changing the MSVSTS_INTELLIJ_RUN_L2_TESTS environment variable.
    * The internal CI build will run these tests
+
+4. To run the reactive client integration tests, create a run configuration for `:client:backend:test` task, or use Gradle to run it. It uses the same environment variables as L2 tests.
 
 ## Learn More
 

--- a/client/backend/build.gradle
+++ b/client/backend/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     compile project("tfs-sdk")
     compile "com.jetbrains.rd:rd-framework:$rdGenVersion"
+
+    testImplementation 'junit:junit:4.12'
 }
 
 compileKotlin {
@@ -41,6 +43,8 @@ task docs(type: Copy, dependsOn: ["tfs-sdk:downloadArchive", "tfs-sdk:verifyArch
     }
     into docs
 }
+
+test.onlyIf { "true".equalsIgnoreCase(System.getenv("MSVSTS_INTELLIJ_RUN_L2_TESTS")) }
 
 distributions {
     main {

--- a/client/backend/src/main/kotlin/com/microsoft/tfs/Main.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/Main.kt
@@ -119,7 +119,7 @@ private fun initializeCollection(lifetime: Lifetime, definition: TfsCollectionDe
     }
 
     collection.deleteFilesRecursively.set { paths ->
-        if (paths.isEmpty()) return@set TfsDeleteSuccess()
+        if (paths.isEmpty()) return@set TfsDeleteResult(emptyList(), emptyList(), emptyList())
 
         logPaths("Recursive Delete", paths)
         client.deletePathsRecursively(paths)

--- a/client/backend/src/main/kotlin/com/microsoft/tfs/Main.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/Main.kt
@@ -119,7 +119,7 @@ private fun initializeCollection(lifetime: Lifetime, definition: TfsCollectionDe
     }
 
     collection.deleteFilesRecursively.set { paths ->
-        if (paths.isEmpty()) return@set
+        if (paths.isEmpty()) return@set TfsDeleteSuccess()
 
         logPaths("Recursive Delete", paths)
         client.deletePathsRecursively(paths)

--- a/client/backend/src/main/kotlin/com/microsoft/tfs/TfsClient.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/TfsClient.kt
@@ -39,6 +39,9 @@ class TfsClient(lifetime: Lifetime, serverUri: URI, credentials: Credentials) {
 
         client = collection.versionControlClient.also {
             it.pathWatcherFactory = pathWatcherFactory
+            it.eventEngine.addNonFatalErrorListener { event ->
+                logger.warn { event.message }
+            }
         }
     }
 

--- a/client/backend/src/main/kotlin/com/microsoft/tfs/TfsClient.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/TfsClient.kt
@@ -31,7 +31,7 @@ class TfsClient(lifetime: Lifetime, serverUri: URI, credentials: Credentials) {
         private val logger = Logging.getLogger<TfsClient>()
     }
 
-    private val client: VersionControlClient
+    val client: VersionControlClient
     private val pathWatcherFactory = ExternallyControlledPathWatcherFactory(lifetime)
     init {
         val collection = TFSTeamProjectCollection(serverUri, credentials)

--- a/client/backend/src/main/kotlin/com/microsoft/tfs/sdk/VersionControlEventEngineEx.kt
+++ b/client/backend/src/main/kotlin/com/microsoft/tfs/sdk/VersionControlEventEngineEx.kt
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.tfs.sdk
+
+import com.microsoft.tfs.core.clients.versioncontrol.events.NewPendingChangeListener
+import com.microsoft.tfs.core.clients.versioncontrol.events.NonFatalErrorListener
+import com.microsoft.tfs.core.clients.versioncontrol.events.UndonePendingChangeListener
+import com.microsoft.tfs.core.clients.versioncontrol.events.VersionControlEventEngine
+
+fun VersionControlEventEngine.withUndonePendingChangeListener(
+    listener: UndonePendingChangeListener,
+    action: () -> Unit) {
+    addUndonePendingChangeListener(listener)
+    try {
+        action()
+    } finally {
+        removeUndonePendingChangeListener(listener)
+    }
+}
+
+fun VersionControlEventEngine.withNewPendingChangeListener(
+    listener: NewPendingChangeListener,
+    action: () -> Unit) {
+    addNewPendingChangeListener(listener)
+    try {
+        action()
+    } finally {
+        removeNewPendingChangeListener(listener)
+    }
+}
+
+
+fun VersionControlEventEngine.withNonFatalErrorListener(
+    listener: NonFatalErrorListener,
+    action: () -> Unit) {
+    addNonFatalErrorListener(listener)
+    try {
+        action()
+    } finally {
+        removeNonFatalErrorListener(listener)
+    }
+}

--- a/client/backend/src/test/kotlin/com/microsoft/tfs/TfsClientTests.kt
+++ b/client/backend/src/test/kotlin/com/microsoft/tfs/TfsClientTests.kt
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.tfs
+
+import com.google.common.io.Files
+import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.PendingSet
+import com.microsoft.tfs.model.host.TfsDeleteFailure
+import com.microsoft.tfs.model.host.TfsLocalPath
+import com.microsoft.tfs.tests.*
+import org.apache.commons.io.FileUtils.deleteDirectory
+import org.apache.log4j.Level
+import org.junit.Assert
+import org.junit.Test
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+
+class TfsClientTests : LifetimedTest() {
+
+    companion object {
+        private fun assertNoPendingChanges(client: TfsClient, path: Path) {
+            val states = client.status(listOf(TfsLocalPath(path.toString())))
+            Assert.assertEquals("There should be no changes in $path", emptyList<PendingSet>(), states)
+        }
+
+        private fun ignoreItem(workspace: Path, item: String) {
+            val tfIgnore = workspace.resolve(".tfignore")
+
+            @Suppress("UnstableApiUsage")
+            Files.append("\n$item", tfIgnore.toFile(), StandardCharsets.UTF_8)
+        }
+    }
+
+    override fun setUp() {
+        Logging.initialize(null, Level.INFO)
+        super.setUp()
+        IntegrationTestUtils.ensureInitialized()
+    }
+
+    @Test
+    fun clientShouldThrowExceptionWhenTryingToDeleteIgnoredItem() {
+        val workspace = cloneTestRepository()
+        try {
+            val client = createClient(testLifetime)
+            val fileName = ".idea/libraries/something.xml"
+            val filePath = workspace.resolve(fileName)
+            filePath.parent.toFile().mkdirs()
+
+            @Suppress("UnstableApiUsage")
+            Files.write("testfile", filePath.toFile(), StandardCharsets.UTF_8)
+
+            ignoreItem(workspace, ".idea")
+            assertNoPendingChanges(client, filePath)
+
+            val result = client.deletePathsRecursively(listOf(TfsLocalPath(filePath.toString()))) as TfsDeleteFailure
+            Assert.assertEquals(listOf(TfsLocalPath(filePath.toString())), result.failedPaths)
+        } finally {
+            deleteWorkspace(workspace)
+            deleteDirectory(workspace.toFile())
+        }
+    }
+}

--- a/client/backend/src/test/kotlin/com/microsoft/tfs/tests/ClassicClientUtils.kt
+++ b/client/backend/src/test/kotlin/com/microsoft/tfs/tests/ClassicClientUtils.kt
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.tfs.tests
+
+import com.jetbrains.rd.util.info
+import com.microsoft.tfs.Logging
+import org.junit.Assert
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+private val logger = Logging.getLogger("ClassicClientUtilsKt")
+
+private fun executeClient(directory: Path, vararg arguments: String) {
+    logger.info { "Running tf with arguments: [${arguments.joinToString(",")}]" }
+    val loginArgument = "-login:${IntegrationTestUtils.user},${IntegrationTestUtils.pass}"
+    val process = ProcessBuilder(IntegrationTestUtils.tfExe, loginArgument, *arguments)
+        .directory(directory.toFile())
+        .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+        .redirectError(ProcessBuilder.Redirect.INHERIT)
+        .start()
+    val exitCode = process.waitFor()
+    Assert.assertEquals(0, exitCode)
+}
+
+private fun tfCreateWorkspace(workspacePath: Path, name: String) {
+    val collectionUrl = IntegrationTestUtils.serverUrl
+    executeClient(workspacePath, "workspace", "-new", "-collection:$collectionUrl", name)
+}
+
+private fun tfDeleteWorkspace(workspacePath: Path, workspaceName: String) {
+    executeClient(workspacePath, "workspace", "-delete", workspaceName)
+}
+
+private fun tfCreateMapping(workspacePath: Path, workspaceName: String, serverPath: String, localPath: Path) {
+    executeClient(workspacePath, "workfold", "-map", "-workspace:$workspaceName", serverPath, localPath.toString())
+}
+
+private fun tfGet(workspacePath: Path) {
+    executeClient(workspacePath, "get")
+}
+
+fun cloneTestRepository(): Path {
+    val workspacePath = Files.createTempDirectory("adi.b.test.").toFile().canonicalFile.toPath()
+    val workspaceName = "${workspacePath.fileName}.${IntegrationTestUtils.workspaceNameSuffix}"
+    Assert.assertTrue(workspaceName.length <= 64)
+    tfCreateWorkspace(workspacePath, workspaceName)
+    tfCreateMapping(workspacePath, workspaceName, "$/${IntegrationTestUtils.teamProject}", Paths.get("."))
+    tfGet(workspacePath)
+    return workspacePath
+}
+
+fun deleteWorkspace(path: Path) {
+    val workspaceName = "${path.fileName}.${IntegrationTestUtils.workspaceNameSuffix}"
+    tfDeleteWorkspace(path, workspaceName)
+}

--- a/client/backend/src/test/kotlin/com/microsoft/tfs/tests/ClassicClientUtils.kt
+++ b/client/backend/src/test/kotlin/com/microsoft/tfs/tests/ClassicClientUtils.kt
@@ -17,8 +17,14 @@ private fun executeClient(directory: Path, vararg arguments: String) {
     val loginArgument = "-login:${IntegrationTestUtils.user},${IntegrationTestUtils.pass}"
     val process = ProcessBuilder(IntegrationTestUtils.tfExe, loginArgument, *arguments)
         .directory(directory.toFile())
-        .redirectOutput(ProcessBuilder.Redirect.INHERIT)
-        .redirectError(ProcessBuilder.Redirect.INHERIT)
+        .apply {
+            environment().also {
+                it["TF_NOTELEMETRY"] = "TRUE"
+                it["TF_ADDITIONAL_JAVA_ARGS"] = "-Duser.country=US -Duser.language=en"
+                it["TF_USE_KEYCHAIN"] = "FALSE" // will be stuck on com.microsoft.tfs.jni.internal.keychain.NativeKeychain.nativeFindInternetPassword on macOS otherwise
+            }
+        }
+        .inheritIO()
         .start()
     val exitCode = process.waitFor()
     Assert.assertEquals(0, exitCode)

--- a/client/backend/src/test/kotlin/com/microsoft/tfs/tests/ClientUtils.kt
+++ b/client/backend/src/test/kotlin/com/microsoft/tfs/tests/ClientUtils.kt
@@ -5,11 +5,15 @@ package com.microsoft.tfs.tests
 
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.microsoft.tfs.TfsClient
+import com.microsoft.tfs.core.clients.versioncontrol.Workstation
 import com.microsoft.tfs.core.httpclient.UsernamePasswordCredentials
 import java.net.URI
 
 fun createClient(lifetime: Lifetime): TfsClient {
     val serverUri = URI(IntegrationTestUtils.serverUrl)
     val credentials = UsernamePasswordCredentials(IntegrationTestUtils.user, IntegrationTestUtils.pass)
-    return TfsClient(lifetime, serverUri, credentials)
+    val client = TfsClient(lifetime, serverUri, credentials)
+    val workstation = Workstation.getCurrent(client.client.connection.persistenceStoreProvider)
+    workstation.reloadCache()
+    return client
 }

--- a/client/backend/src/test/kotlin/com/microsoft/tfs/tests/ClientUtils.kt
+++ b/client/backend/src/test/kotlin/com/microsoft/tfs/tests/ClientUtils.kt
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.tfs.tests
+
+import com.jetbrains.rd.util.lifetime.Lifetime
+import com.microsoft.tfs.TfsClient
+import com.microsoft.tfs.core.httpclient.UsernamePasswordCredentials
+import java.net.URI
+
+fun createClient(lifetime: Lifetime): TfsClient {
+    val serverUri = URI(IntegrationTestUtils.serverUrl)
+    val credentials = UsernamePasswordCredentials(IntegrationTestUtils.user, IntegrationTestUtils.pass)
+    return TfsClient(lifetime, serverUri, credentials)
+}

--- a/client/backend/src/test/kotlin/com/microsoft/tfs/tests/IntegrationTestUtils.kt
+++ b/client/backend/src/test/kotlin/com/microsoft/tfs/tests/IntegrationTestUtils.kt
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.tfs.tests
+
+import org.junit.Assert
+
+object IntegrationTestUtils {
+    val workspaceNameSuffix: String = System.getenv("MSVSTS_INTELLIJ_VSO_WORKSPACE_SUFFIX") ?: "default"
+    val serverUrl: String = System.getenv("MSVSTS_INTELLIJ_VSO_SERVER_URL")
+    val teamProject: String = System.getenv("MSVSTS_INTELLIJ_VSO_TEAM_PROJECT")
+    val user: String = System.getenv("MSVSTS_INTELLIJ_VSO_USER")
+    val pass: String = System.getenv("MSVSTS_INTELLIJ_VSO_PASS")
+    val tfExe: String = System.getenv("MSVSTS_INTELLIJ_TF_EXE")
+
+    fun ensureInitialized() {
+        val message = "You must provide %s for the L2 tests through the following environment variable: %s"
+        fun assertNotEmpty(name: String, env: String, value: String) {
+            Assert.assertFalse(String.format(message, name, env), value.isEmpty())
+        }
+
+        assertNotEmpty("user", "MSVSTS_INTELLIJ_VSO_USER", user)
+        assertNotEmpty("pass", "MSVSTS_INTELLIJ_VSO_PASS", pass)
+        assertNotEmpty("serverUrl", "MSVSTS_INTELLIJ_VSO_SERVER_URL", serverUrl)
+        assertNotEmpty("teamProject", "MSVSTS_INTELLIJ_VSO_TEAM_PROJECT", teamProject)
+        assertNotEmpty("tfExe", "MSVSTS_INTELLIJ_TF_EXE", tfExe)
+    }
+}

--- a/client/backend/src/test/kotlin/com/microsoft/tfs/tests/LifetimedTest.kt
+++ b/client/backend/src/test/kotlin/com/microsoft/tfs/tests/LifetimedTest.kt
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.tfs.tests
+
+import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rd.util.lifetime.LifetimeDefinition
+import org.junit.After
+import org.junit.Before
+
+abstract class LifetimedTest {
+    private lateinit var testLifetimeDefinition: LifetimeDefinition
+    protected val testLifetime: Lifetime
+        get() = testLifetimeDefinition
+
+    @Before
+    open fun setUp() {
+        testLifetimeDefinition = LifetimeDefinition()
+    }
+
+    @After
+    fun tearDown() {
+        testLifetimeDefinition.terminate()
+    }
+}

--- a/client/backend/src/test/kotlin/com/microsoft/tfs/tests/LifetimedTest.kt
+++ b/client/backend/src/test/kotlin/com/microsoft/tfs/tests/LifetimedTest.kt
@@ -19,7 +19,7 @@ abstract class LifetimedTest {
     }
 
     @After
-    fun tearDown() {
+    open fun tearDown() {
         testLifetimeDefinition.terminate()
     }
 }

--- a/client/backend/tfs-sdk/build.gradle
+++ b/client/backend/tfs-sdk/build.gradle
@@ -11,9 +11,9 @@ plugins {
 }
 
 ext {
-    sdkVersion = "14.135.0"
+    sdkVersion = "14.135.1"
     sdkArchiveLocation = file("$buildDir/TFS-SDK-${sdkVersion}.zip")
-    expectedSdkArchiveHash = "6C7600C40248F986F873829B88429FCACAFFD0CCB70DD7D9F11CB7D4BAA2103D"
+    expectedSdkArchiveHash = "0CB218AB6A3D6312904BE2EFA2258C2009112E3D069ACE331FBCE68CE6389C39"
     sdkUnpackLocation = file("$buildDir/sdk")
     sdkJarName = "com.microsoft.tfs.sdk-${sdkVersion}.jar"
 }

--- a/client/connector/src/main/kotlin/com/microsoft/tfs/connector/ReactiveClientConnection.kt
+++ b/client/connector/src/main/kotlin/com/microsoft/tfs/connector/ReactiveClientConnection.kt
@@ -81,9 +81,9 @@ class ReactiveClientConnection(private val scheduler: IScheduler) {
             collection.invalidatePaths.start(paths).pipeToVoid(lt, this)
         }
 
-    fun deleteFilesRecursivelyAsync(collection: TfsCollection, paths: List<TfsPath>): CompletionStage<Void> =
+    fun deleteFilesRecursivelyAsync(collection: TfsCollection, paths: List<TfsPath>): CompletionStage<TfsDeleteResult> =
         queueFutureAsync { lt ->
-            collection.deleteFilesRecursively.start(paths).pipeToVoid(lt, this)
+            collection.deleteFilesRecursively.start(paths).pipeTo(lt, this)
         }
 
     fun undoLocalChangesAsync(collection: TfsCollection, paths: List<TfsPath>): CompletionStage<List<TfsLocalPath>> =

--- a/client/protocol/src/main/kotlin/model/tfs/TfsModel.kt
+++ b/client/protocol/src/main/kotlin/model/tfs/TfsModel.kt
@@ -69,6 +69,12 @@ object TfsModel : Root() {
         field("fileEncoding", string.nullable)
     }
 
+    private val TfsDeleteResult = basestruct {}
+    private val TfsDeleteSuccess = structdef extends TfsDeleteResult {}
+    private val TfsDeleteFailure = structdef extends TfsDeleteResult {
+        field("failedPaths", immutableList(TfsPath))
+    }
+
     private val TfsCollection = classdef {
         property("isReady", bool)
             .doc("Whether the client is ready to accept method calls")
@@ -85,7 +91,7 @@ object TfsModel : Root() {
         call("invalidatePaths", immutableList(TfsLocalPath), void)
             .doc("Invalidates the paths in the TFS cache")
 
-        call("deleteFilesRecursively", immutableList(TfsPath), void)
+        call("deleteFilesRecursively", immutableList(TfsPath), TfsDeleteResult)
             .doc("Scheduled deletion of the files")
 
         call("undoLocalChanges", immutableList(TfsPath), immutableList(TfsLocalPath))

--- a/client/protocol/src/main/kotlin/model/tfs/TfsModel.kt
+++ b/client/protocol/src/main/kotlin/model/tfs/TfsModel.kt
@@ -69,10 +69,10 @@ object TfsModel : Root() {
         field("fileEncoding", string.nullable)
     }
 
-    private val TfsDeleteResult = basestruct {}
-    private val TfsDeleteSuccess = structdef extends TfsDeleteResult {}
-    private val TfsDeleteFailure = structdef extends TfsDeleteResult {
-        field("failedPaths", immutableList(TfsPath))
+    private val TfsDeleteResult = structdef {
+        field("deletedPaths", immutableList(TfsLocalPath))
+        field("notFoundPaths", immutableList(TfsPath))
+        field("errorMessages", immutableList(string))
     }
 
     private val TfsCollection = classdef {

--- a/plugin/resources/META-INF/plugin.xml
+++ b/plugin/resources/META-INF/plugin.xml
@@ -60,7 +60,8 @@
       <br />
       <ul>
         <li>Repository history refresh has been made significantly faster when Reactive client is enabled</li>
-          <li>Fixed a failure to edit a workspace inside of a TFS collection when the collection name had a space (<a href="https://github.com/microsoft/azure-devops-intellij/issues/326">#326</a>)</li>
+        <li>TFVC client is now able to successfully delete ignored files (<a href="https://github.com/microsoft/azure-devops-intellij/issues/330">#330</a>)</li>
+        <li>Fixed a failure to edit a workspace inside of a TFS collection when the collection name had a space (<a href="https://github.com/microsoft/azure-devops-intellij/issues/326">#326</a>)</li>
       </ul>
       <br />
     ]]>

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/DeleteCommand.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/DeleteCommand.java
@@ -4,18 +4,28 @@
 package com.microsoft.alm.plugin.external.commands;
 
 import com.microsoft.alm.common.utils.ArgumentHelper;
-import com.microsoft.alm.helpers.Path;
 import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.external.ToolRunner;
+import com.microsoft.alm.plugin.idea.tfvc.core.TfvcDeleteResult;
+import com.microsoft.alm.plugin.idea.tfvc.core.tfs.TfsFileUtil;
+import com.microsoft.tfs.model.connector.TfsLocalPath;
+import com.microsoft.tfs.model.connector.TfsPath;
+import org.apache.commons.compress.utils.Lists;
 import org.apache.commons.lang.StringUtils;
 
-import java.util.ArrayList;
+import java.nio.file.Paths;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-public class DeleteCommand extends Command<List<String>> {
+public class DeleteCommand extends Command<TfvcDeleteResult> {
     private final List<String> filePaths;
     private final boolean recursive;
     private final String workspace;
+
+    private static final Pattern FILE_NOT_FOUND_PATTERN =
+            Pattern.compile("^No matching items found in (.*?) in your workspace, or you do not have permission to access them.$");
+    private static final String NO_FILES_TO_DELETE = "No arguments matched any files to delete.";
 
     public DeleteCommand(ServerContext context, List<String> filePaths, String workspace, boolean recursive) {
         super("delete", context);
@@ -43,31 +53,66 @@ public class DeleteCommand extends Command<List<String>> {
         return builder;
     }
 
-    /**
-     * Example
-     * tf delete dir/file.txt
-     * <p>
-     * dir:
-     * file.txt
-     *
-     * @param stdout
-     * @param stderr
-     * @return
-     */
-    public List<String> parseOutput(String stdout, String stderr) {
-        super.throwIfError(stderr);
+    private static void parseStdErr(String stderr, List<TfsPath> notFoundFiles, List<String> errorMessages) {
+        String[] lines = stderr.split("\r\n|\n");
+        for (String line : lines) {
+            if (StringUtils.isEmpty(line))
+                continue;
+
+            if (line.equals(NO_FILES_TO_DELETE)) // skip this warning, we'll report each item separately
+                continue;
+
+            Matcher notFoundMatcher = FILE_NOT_FOUND_PATTERN.matcher(line);
+            if (notFoundMatcher.matches()) {
+                String filePath = notFoundMatcher.group(1);
+                TfsLocalPath localPath = TfsFileUtil.createLocalPath(filePath);
+                notFoundFiles.add(localPath);
+            } else {
+                errorMessages.add(line);
+            }
+        }
+    }
+
+    private void parseStdOut(String stdout, List<java.nio.file.Path> deletedPaths) {
         final String[] lines = getLines(stdout);
-        final List<String> deletedFiles = new ArrayList<String>();
         String path = StringUtils.EMPTY;
 
         for (final String line : lines) {
+            if (StringUtils.isEmpty(line))
+                continue;
+
             if (line.endsWith(":")) {
                 path = line.substring(0, line.length() - 1);
-            } else if (StringUtils.isNotEmpty(line)) {
-                deletedFiles.add(Path.combine(path, line));
+            } else {
+                deletedPaths.add(Paths.get(path, line));
             }
         }
+    }
 
-        return deletedFiles;
+    /**
+     * Example command line: {@code tf delete dir/file.txt}
+     * <p>
+     * Example stdout:<br>
+     * <pre>{@code dir:
+     * file.txt}</pre>
+     * <p>
+     * Example stderr:<br>
+     * <pre>{@code The item C:\FullPath\dir\file.txt could not be found in your workspace, or you do not have permission to access it.}</pre>
+     */
+    public TfvcDeleteResult parseOutput(String stdout, String stderr) {
+        List<java.nio.file.Path> deletedPaths = Lists.newArrayList();
+        List<TfsPath> notFoundFiles = Lists.newArrayList();
+        List<String> errorMessages = Lists.newArrayList();
+
+        parseStdErr(stderr, notFoundFiles, errorMessages);
+        parseStdOut(stdout, deletedPaths);
+
+        return new TfvcDeleteResult(deletedPaths, notFoundFiles, errorMessages);
+    }
+
+    @Override
+    protected boolean shouldThrowBadExitCode() {
+        // This command parses all the errors and reports them as an object returned; no need to check the exit code.
+        return false;
     }
 }

--- a/plugin/src/com/microsoft/alm/plugin/external/reactive/ReactiveTfvcClientHost.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/reactive/ReactiveTfvcClientHost.java
@@ -29,6 +29,7 @@ import com.microsoft.tfs.connector.ReactiveClientConnection;
 import com.microsoft.tfs.model.connector.TfsCollection;
 import com.microsoft.tfs.model.connector.TfsCollectionDefinition;
 import com.microsoft.tfs.model.connector.TfsCredentials;
+import com.microsoft.tfs.model.connector.TfsDeleteResult;
 import com.microsoft.tfs.model.connector.TfsLocalPath;
 import com.microsoft.tfs.model.connector.TfsPath;
 import org.jetbrains.annotations.NotNull;
@@ -152,7 +153,7 @@ public class ReactiveTfvcClientHost {
     }
 
     @NotNull
-    public CompletionStage<Void> deleteFilesRecursivelyAsync(
+    public CompletionStage<TfsDeleteResult> deleteFilesRecursivelyAsync(
             @NotNull ServerIdentification serverIdentification,
             @NotNull List<TfsPath> paths) {
         return getReadyCollectionAsync(serverIdentification)

--- a/plugin/src/com/microsoft/alm/plugin/external/utils/CommandUtils.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/utils/CommandUtils.java
@@ -53,6 +53,7 @@ import com.microsoft.alm.plugin.external.models.TfvcLabel;
 import com.microsoft.alm.plugin.external.models.VersionSpec;
 import com.microsoft.alm.plugin.external.models.Workspace;
 import com.microsoft.alm.plugin.idea.tfvc.core.TFVCNotifications;
+import com.microsoft.alm.plugin.idea.tfvc.core.TfvcDeleteResult;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -702,8 +703,8 @@ public class CommandUtils {
      * @param recursive
      * @return
      */
-    public static List<String> deleteFiles(final ServerContext context, final List<String> filePaths,
-                                           final String workingFolder, final boolean recursive) {
+    public static TfvcDeleteResult deleteFiles(final ServerContext context, final List<String> filePaths,
+                                               final String workingFolder, final boolean recursive) {
         final DeleteCommand deleteCommand = new DeleteCommand(context, filePaths, workingFolder, recursive);
         return deleteCommand.runSynchronously();
     }

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TfvcClient.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TfvcClient.java
@@ -94,8 +94,7 @@ public interface TfvcClient {
     }
 
     /**
-     * Deletes the passed paths recursively using the TFS client. Will be finished with an exception if some paths
-     * weren't processed by the client successfully.
+     * Deletes the passed paths recursively using the TFS client.
      *
      * @param serverContext server context to authenticate.
      * @param items         items to delete.
@@ -103,20 +102,19 @@ public interface TfvcClient {
      * are done.
      */
     @NotNull
-    CompletionStage<Void> deleteFilesRecursivelyAsync(
+    CompletionStage<TfvcDeleteResult> deleteFilesRecursivelyAsync(
             @NotNull ServerContext serverContext,
             @NotNull List<TfsPath> items);
 
     /**
-     * Deletes the passed paths recursively using the TFS client. Will throw an exception if some paths weren't
-     * processed by the client successfully.
+     * Deletes the passed paths recursively using the TFS client.
      *
      * @param serverContext server context to authenticate.
      * @param items         items to delete.
      */
-    default void deleteFilesRecursively(@NotNull ServerContext serverContext, @NotNull List<TfsPath> items) {
+    default TfvcDeleteResult deleteFilesRecursively(@NotNull ServerContext serverContext, @NotNull List<TfsPath> items) {
         try {
-            deleteFilesRecursivelyAsync(serverContext, items).toCompletableFuture().get();
+            return deleteFilesRecursivelyAsync(serverContext, items).toCompletableFuture().get();
         } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException(e);
         }

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TfvcClient.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TfvcClient.java
@@ -93,11 +93,27 @@ public interface TfvcClient {
         }
     }
 
+    /**
+     * Deletes the passed paths recursively using the TFS client. Will be finished with an exception if some paths
+     * weren't processed by the client successfully.
+     *
+     * @param serverContext server context to authenticate.
+     * @param items         items to delete.
+     * @return a completion stage that will be finished after the call is completely finished and all of the callbacks
+     * are done.
+     */
     @NotNull
     CompletionStage<Void> deleteFilesRecursivelyAsync(
             @NotNull ServerContext serverContext,
             @NotNull List<TfsPath> items);
 
+    /**
+     * Deletes the passed paths recursively using the TFS client. Will throw an exception if some paths weren't
+     * processed by the client successfully.
+     *
+     * @param serverContext server context to authenticate.
+     * @param items         items to delete.
+     */
     default void deleteFilesRecursively(@NotNull ServerContext serverContext, @NotNull List<TfsPath> items) {
         try {
             deleteFilesRecursivelyAsync(serverContext, items).toCompletableFuture().get();

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TfvcDeleteResult.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TfvcDeleteResult.java
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.alm.plugin.idea.tfvc.core;
+
+import com.google.common.collect.Lists;
+import com.microsoft.alm.plugin.idea.tfvc.core.tfs.TfsFileUtil;
+import com.microsoft.tfs.model.connector.TfsPath;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A result of TFVC delete operation.
+ */
+public class TfvcDeleteResult {
+    private final List<Path> deletedPaths;
+    private final List<TfsPath> notFoundPaths;
+    private final List<String> errorMessages;
+
+    public TfvcDeleteResult() {
+        this(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+    }
+
+    public TfvcDeleteResult(List<Path> deletedPaths, List<TfsPath> notFoundPaths, List<String> errorMessages) {
+        this.deletedPaths = deletedPaths;
+        this.notFoundPaths = notFoundPaths;
+        this.errorMessages = errorMessages;
+    }
+
+    public TfvcDeleteResult mergeWith(TfvcDeleteResult other) {
+        List<Path> newDeletedPaths = Lists.newArrayList(deletedPaths);
+        List<TfsPath> newNotFoundPaths = Lists.newArrayList(notFoundPaths);
+        List<String> newErrorMessages = Lists.newArrayList(errorMessages);
+
+        newDeletedPaths.addAll(other.deletedPaths);
+        newNotFoundPaths.addAll(other.notFoundPaths);
+        newErrorMessages.addAll(other.errorMessages);
+
+        return new TfvcDeleteResult(newDeletedPaths, newNotFoundPaths, newErrorMessages);
+    }
+
+    public List<Path> getDeletedPaths() {
+        return deletedPaths;
+    }
+
+    /**
+     * List of paths that weren't found in the repository and thus couldn't be deleted.
+     */
+    public List<TfsPath> getNotFoundPaths() {
+        return notFoundPaths;
+    }
+
+    /**
+     * Other error messages that happened during the operation, except "file not found" message.
+     */
+    public List<String> getErrorMessages() {
+        return errorMessages;
+    }
+
+    public void throwIfErrorMessagesAreNotEmpty() throws IOException {
+        if (!errorMessages.isEmpty()) {
+            throw new IOException(
+                    "Error occurred when trying to delete files:\n"
+                            + String.join("\n", errorMessages));
+        }
+    }
+
+    public void throwIfNotFoundPathsAreNotEmpty() throws IOException {
+        if (!notFoundPaths.isEmpty()) {
+            List<String> fileNames = notFoundPaths.stream()
+                    .map(TfsFileUtil::getPathItem)
+                    .collect(Collectors.toList());
+            throw new IOException(
+                    "TFVC client wasn't able to not delete the following files:\n"
+                            + String.join("\n", fileNames));
+        }
+    }
+}

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TfsFileUtil.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/tfs/TfsFileUtil.java
@@ -40,6 +40,8 @@ import com.microsoft.alm.plugin.idea.tfvc.exceptions.TfsException;
 import com.microsoft.alm.plugin.versioncontrol.path.LocalPath;
 import com.microsoft.alm.plugin.versioncontrol.path.ServerPath;
 import com.microsoft.tfs.model.connector.TfsLocalPath;
+import com.microsoft.tfs.model.connector.TfsPath;
+import com.microsoft.tfs.model.connector.TfsServerPath;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -87,6 +89,15 @@ public class TfsFileUtil {
 
     public static TfsLocalPath createLocalPath(VirtualFile file) {
         return createLocalPath(file.getPath());
+    }
+
+    public static String getPathItem(TfsPath path) {
+        if (path instanceof TfsLocalPath)
+            return ((TfsLocalPath) path).getPath();
+        else if (path instanceof TfsServerPath)
+            return ((TfsServerPath) path).getPath();
+        else
+            throw new RuntimeException("Unknown path type: " + path);
     }
 
     public static boolean isServerItem(final String itemPath) {

--- a/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListenerTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListenerTest.java
@@ -30,6 +30,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -38,6 +39,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -123,6 +125,10 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
         when(mockTFSVcs.getServerContext(anyBoolean())).thenReturn(mockServerContext);
         when(TFSVcs.getInstance(mockProject)).thenReturn(mockTFSVcs);
         when(TFVCUtil.isInvalidTFVCPath(eq(mockTFSVcs), any(FilePath.class))).thenReturn(false);
+        when(
+                CommandUtils.deleteFiles(
+                        any(ServerContext.class), anyListOf(String.class), any(String.class), any(Boolean.class)))
+                .thenReturn(new TfvcDeleteResult());
 
         FilePath mockFilePath = mock(FilePath.class);
         when(VersionControlPath.getFilePath(CURRENT_FILE_PATH, false)).thenReturn(mockFilePath);
@@ -384,7 +390,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     }
 
     @Test
-    public void testDelete_FileRename() {
+    public void testDelete_FileRename() throws IOException {
         when(mockPendingChange.getSourceItem()).thenReturn("$/server/path/to/file.txt");
         when(mockPendingChange.getWorkspace()).thenReturn("testDelete_FileRename.workspace");
         when(mockPendingChange.isCandidate()).thenReturn(false);
@@ -414,7 +420,7 @@ public class TFSFileSystemListenerTest extends IdeaAbstractTest {
     }
 
     @Test
-    public void testDelete_FileRenameEdit() {
+    public void testDelete_FileRenameEdit() throws IOException {
         when(mockPendingChange.getSourceItem()).thenReturn("$/server/path/to/file.txt");
         when(mockPendingChange.getWorkspace()).thenReturn("testDelete_FileRenameEdit.workspace");
         when(mockPendingChange.isCandidate()).thenReturn(false);

--- a/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/TFSRollbackEnvironmentTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/tfvc/core/TFSRollbackEnvironmentTest.java
@@ -18,6 +18,7 @@ import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.external.utils.CommandUtils;
 import com.microsoft.alm.plugin.idea.IdeaAbstractTest;
 import com.microsoft.alm.plugin.idea.tfvc.core.tfs.TfsFileUtil;
+import com.microsoft.tfs.model.connector.TfsPath;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -82,6 +83,7 @@ public class TFSRollbackEnvironmentTest extends IdeaAbstractTest {
         when(LocalFileSystem.getInstance()).thenReturn(mockLocalFileSystem);
         when(TfsFileUtil.createLocalPath(any(String.class))).thenCallRealMethod();
         when(TfsFileUtil.createLocalPath(any(FilePath.class))).thenCallRealMethod();
+        when(TfsFileUtil.getPathItem(any(TfsPath.class))).thenCallRealMethod();
         when(filePath1.getPath()).thenReturn("/path/to/file1");
         when(filePath2.getPath()).thenReturn("/path/to/file2");
         when(filePath3.getPath()).thenReturn("/path/to/file3");

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -40,7 +40,7 @@ jobs:
         inputs:
           jdkVersionOption: 1.8
           options: '--info'
-          tasks: L2test:cleanTest L2test:test
+          tasks: L2test:cleanTest L2test:test :client:backend:test
         env:
           MSVSTS_INTELLIJ_RUN_L2_TESTS: true
           MSVSTS_INTELLIJ_TF_EXE: $(Build.SourcesDirectory)/.azure/.installed/tfs-clc/TEE-CLC-14.134.0/$(tfClcScriptName)

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -68,18 +68,25 @@ jobs:
 #          artifact: '$(System.JobId).$(build.buildNumber).$(Agent.OS)-test-reports'
 #
 #      - task: PublishPipelineArtifact@1
-#        displayName: "Publish integration test reports"
+#        displayName: "Publish L2 test reports"
 #        condition: eq(variables['System.PullRequest.IsFork'], false)
 #        inputs:
 #          path: 'L2Tests/build/reports'
 #          artifact: '$(System.JobId).$(build.buildNumber).$(Agent.OS)-integration-test-reports'
 #
 #      - task: PublishPipelineArtifact@1
-#        displayName: "Publish integration test logs"
+#        displayName: "Publish L2 test logs"
 #        condition: eq(variables['System.PullRequest.IsFork'], false)
 #        inputs:
 #          path: 'L2Tests/build/idea-sandbox/system-test/testlog'
 #          artifact: '$(System.JobId).$(build.buildNumber).$(Agent.OS)-integration-test-logs'
+#
+#      - task: PublishPipelineArtifact@1
+#        displayName: "Publish backend integration test reports"
+#        condition: eq(variables['System.PullRequest.IsFork'], false)
+#        inputs:
+#          path: 'client/backend/build/reports'
+#          artifact: '$(build.buildNumber).$(Agent.OS)-backend-test-reports'
 
   - job: test_build # check compilation for newest IDEA
     pool:


### PR DESCRIPTION
Closes #330.

This PR modifies the behavior of delete operation for both classic and reactive clients, and makes them to behave the same: they won't throw any exceptions on delete, but will return three collections:
- files actually deleted
- files that weren't found
- any other error messages (should be asserted by caller to be empty)

With these changes, it's now possible to distinguish the situations when there was a delete error, and the situations when the client wasn't able to found a TFVC item we're about to delete.

In the latter case, it means the item was probably explicitly ignored by the user, so we could let IDEA to proceed with the item delete operation, and shouldn't handle this item via the TFVC client.

Another big change included into this PR is the reactive client test addition: from now on, the reactive client backend will be tested by our test suite, too.

Also, to enable the tests, I had to [fix a small bug](https://github.com/JetBrains/team-explorer-everywhere/pull/17/commits/5c660a271dbb5d3fa38cbbd8450b0f751cdc18ed) in our fork of TFS SDK, and update its version to 14.135.1.