### PR TITLE
Update integration tests: use unique repository names for Git

### DIFF
--- a/L2Tests/test/com/microsoft/alm/L2/L2Test.java
+++ b/L2Tests/test/com/microsoft/alm/L2/L2Test.java
@@ -19,6 +19,7 @@ import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory;
 import com.intellij.util.ObjectUtils;
 import com.intellij.util.ThrowableRunnable;
+import com.microsoft.alm.common.utils.SystemHelper;
 import com.microsoft.alm.plugin.authentication.AuthenticationInfo;
 import com.microsoft.alm.plugin.authentication.MockAuthenticationProvider;
 import com.microsoft.alm.plugin.authentication.VsoAuthenticationProvider;
@@ -67,7 +68,7 @@ import java.util.List;
 
 @RunWith(JUnit38ClassRunner.class)
 public abstract class L2Test extends UsefulTestCase {
-    protected static final String ENV_VSO_WORKSPACE_SUFFIX = "MSVSTS_INTELLIJ_VSO_WORKSPACE_SUFFIX";
+    protected static final String ENV_UNIQUE_SUFFIX = "MSVSTS_INTELLIJ_UNIQUE_SUFFIX";
     static {
         Logger.setFactory(TestLoggerFactory.class);
     }
@@ -125,6 +126,18 @@ public abstract class L2Test extends UsefulTestCase {
 
     public String getLegacyRepoUrl() {
         return legacyRepoUrl;
+    }
+
+    /**
+     * Returns name unique enough for test purposes. Adds value of {@link L2Test::ENV_UNIQUE_SUFFIX} to the passed
+     * prefix.
+     */
+    protected String generateUniqueName(String prefix) {
+        String suffix = System.getenv(ENV_UNIQUE_SUFFIX);
+        if (StringUtils.isEmpty(suffix))
+            return prefix + "." + SystemHelper.getComputerName();
+
+        return prefix + "." + suffix;
     }
 
     private AuthenticationInfo getAuthenticationInfo() {

--- a/L2Tests/test/com/microsoft/alm/L2/git/GitImportTest.java
+++ b/L2Tests/test/com/microsoft/alm/L2/git/GitImportTest.java
@@ -5,7 +5,6 @@ package com.microsoft.alm.L2.git;
 
 import com.intellij.openapi.util.io.FileUtil;
 import com.microsoft.alm.L2.L2Test;
-import com.microsoft.alm.common.utils.SystemHelper;
 import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.idea.common.ui.common.ServerContextTableModel;
 import com.microsoft.alm.plugin.idea.git.ui.vcsimport.ImportModel;
@@ -42,8 +41,7 @@ public class GitImportTest extends L2Test {
     public void testImport_VSO() throws Exception {
         Debug.println("Start", null);
         final ImportModel importModel = new ImportModel(myProject, null, null, false);
-        // Get a repo name that is unique for this computer - so tests running in parallel do not conflict
-        final String repoName = "testRepo-" + SystemHelper.getComputerName();
+        final String repoName = generateUniqueName("testRepo");
 
         final File projectPath = new File(myProjectPath);
 

--- a/L2Tests/test/com/microsoft/alm/L2/tfvc/TfvcCheckoutTest.java
+++ b/L2Tests/test/com/microsoft/alm/L2/tfvc/TfvcCheckoutTest.java
@@ -29,12 +29,7 @@ public class TfvcCheckoutTest extends L2Test {
     public static final String README_FILE = "readme.txt";
 
     private String getWorkspaceName() {
-        String teamProject = getTeamProject();
-        String suffix = System.getenv(ENV_VSO_WORKSPACE_SUFFIX);
-        if (suffix == null)
-            return teamProject;
-
-        return teamProject + "." + suffix;
+        return generateUniqueName(getTeamProject());
     }
 
     private void deleteWorkspaceIfExists(ServerContext context, String workspaceName) {

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Here are the steps to setup your environment:
    * `MSVSTS_INTELLIJ_VSO_SERVER_URL=https://organization.visualstudio.com` (make sure no trailing slash here)
    * `MSVSTS_INTELLIJ_VSO_TEAM_PROJECT=projectName`
    * `MSVSTS_INTELLIJ_VSO_USER=EmailAddressForUser`
-   * `MSVSTS_INTELLIJ_VSO_WORKSPACE_SUFFIX=""`: you may leave it empty; if not empty, it will be used as a suffix for workspace name in TFVC tests; introduced for simultaneous test execution on agents
+   * `MSVSTS_INTELLIJ_UNIQUE_SUFFIX=""`: you may leave it empty; if not empty, it will be used as a suffix for various names in tests; introduced for simultaneous test execution on agents
    
    _Note_: Do not use https://dev.azure.com/account/ addresses in these environment variables, make sure to use https://account.visualstudio.com/
 

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -50,7 +50,7 @@ jobs:
           MSVSTS_INTELLIJ_VSO_SERVER_URL: $(VSO_SERVER_URL)
           MSVSTS_INTELLIJ_VSO_TEAM_PROJECT: $(VSO_TEAM_PROJECT)
           MSVSTS_INTELLIJ_VSO_USER: $(VSO_USER)
-          MSVSTS_INTELLIJ_VSO_WORKSPACE_SUFFIX: $(Agent.OS).$(Build.BuildNumber)
+          MSVSTS_INTELLIJ_UNIQUE_SUFFIX: $(Agent.OS).$(Build.BuildNumber)
 
       - task: PublishPipelineArtifact@1
         displayName: "Publish Artifact: $(build.buildNumber)"

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -52,40 +52,41 @@ jobs:
           MSVSTS_INTELLIJ_VSO_USER: $(VSO_USER)
           MSVSTS_INTELLIJ_UNIQUE_SUFFIX: $(Agent.OS).$(Build.BuildNumber)
 
-      - task: PublishPipelineArtifact@1
-        displayName: "Publish Artifact: $(build.buildNumber)"
-        condition: and(eq(variables['System.PullRequest.IsFork'], false), eq(variables['Agent.OS'], 'Linux'))
-        inputs:
-          path: 'plugin/build/distributions'
-          artifact: 'artifact.$(build.buildNumber).$(System.JobId)'
-
-      - task: PublishPipelineArtifact@1
-        displayName: "Publish unit test reports"
-        condition: always()
-        inputs:
-          path: 'plugin/build/reports'
-          artifact: '$(Agent.OS)-test-reports.$(build.buildNumber).$(System.JobId)'
-
-      - task: PublishPipelineArtifact@1
-        displayName: "Publish L2 test reports"
-        condition: eq(variables['System.PullRequest.IsFork'], false)
-        inputs:
-          path: 'L2Tests/build/reports'
-          artifact: '$(Agent.OS)-l2-test-reports.$(build.buildNumber).$(System.JobId)'
-
-      - task: PublishPipelineArtifact@1
-        displayName: "Publish L2 test logs"
-        condition: eq(variables['System.PullRequest.IsFork'], false)
-        inputs:
-          path: 'L2Tests/build/idea-sandbox/system-test/testlog'
-          artifact: '$(Agent.OS)-l2-test-logs.$(build.buildNumber).$(System.JobId)'
-
-      - task: PublishPipelineArtifact@1
-        displayName: "Publish backend integration test reports"
-        condition: eq(variables['System.PullRequest.IsFork'], false)
-        inputs:
-          path: 'client/backend/build/reports'
-          artifact: '$(Agent.OS)-backend-test-reports.$(build.buildNumber).$(System.JobId)'
+# Disabled for publish failure investigation.
+#      - task: PublishPipelineArtifact@1
+#        displayName: "Publish Artifact: $(build.buildNumber)"
+#        condition: and(eq(variables['System.PullRequest.IsFork'], false), eq(variables['Agent.OS'], 'Linux'))
+#        inputs:
+#          path: 'plugin/build/distributions'
+#          artifact: 'artifact.$(build.buildNumber).$(System.JobId)'
+#
+#      - task: PublishPipelineArtifact@1
+#        displayName: "Publish unit test reports"
+#        condition: always()
+#        inputs:
+#          path: 'plugin/build/reports'
+#          artifact: '$(Agent.OS)-test-reports.$(build.buildNumber).$(System.JobId)'
+#
+#      - task: PublishPipelineArtifact@1
+#        displayName: "Publish L2 test reports"
+#        condition: eq(variables['System.PullRequest.IsFork'], false)
+#        inputs:
+#          path: 'L2Tests/build/reports'
+#          artifact: '$(Agent.OS)-l2-test-reports.$(build.buildNumber).$(System.JobId)'
+#
+#      - task: PublishPipelineArtifact@1
+#        displayName: "Publish L2 test logs"
+#        condition: eq(variables['System.PullRequest.IsFork'], false)
+#        inputs:
+#          path: 'L2Tests/build/idea-sandbox/system-test/testlog'
+#          artifact: '$(Agent.OS)-l2-test-logs.$(build.buildNumber).$(System.JobId)'
+#
+#      - task: PublishPipelineArtifact@1
+#        displayName: "Publish backend integration test reports"
+#        condition: eq(variables['System.PullRequest.IsFork'], false)
+#        inputs:
+#          path: 'client/backend/build/reports'
+#          artifact: '$(Agent.OS)-backend-test-reports.$(build.buildNumber).$(System.JobId)'
 
   - job: test_build # check compilation for newest IDEA
     pool:


### PR DESCRIPTION
I suspect that some of the test failures are due to the similarly-named Git repositories being created and deleted on various test agents, and we already have a somwehat unique string for TFVC tests, so I've decided we could reuse it in the Git tests.

Also, I had to disable the pipeline artifact publishing once again, since it is still very unstable. The situation is under invesigation, but I think we'll stop wasting our time on trying to make it work. It's not worth it.