### PR TITLE
Fix null being passed as OK button text in the lock dialog

### DIFF
--- a/plugin/resources/META-INF/plugin.xml
+++ b/plugin/resources/META-INF/plugin.xml
@@ -62,6 +62,7 @@
         <li>Repository history refresh has been made significantly faster when Reactive client is enabled</li>
         <li>TFVC client is now able to successfully delete ignored files (<a href="https://github.com/microsoft/azure-devops-intellij/issues/330">#330</a>)</li>
         <li>Fixed a failure to edit a workspace inside of a TFS collection when the collection name had a space (<a href="https://github.com/microsoft/azure-devops-intellij/issues/326">#326</a>)</li>
+        <li>Fixed a failure to lock an item under TFVC (<a href="https://github.com/microsoft/azure-devops-intellij/issues/345">#345</a>)</li>
       </ul>
       <br />
     ]]>

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/ui/common/BaseDialogImpl.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/ui/common/BaseDialogImpl.java
@@ -40,15 +40,22 @@ public class BaseDialogImpl extends DialogWrapper implements BaseDialog {
         this(project, title, okButtonText, feedbackContext, true, null);
     }
 
-    public BaseDialogImpl(final Project project, final String title, final String okButtonText, final String feedbackContext, final boolean showFeedback, final Map<String, Object> properties) {
+    public BaseDialogImpl(
+            @Nullable Project project,
+            @NotNull String title,
+            @Nullable String okButtonText,
+            @Nullable String feedbackContext,
+            boolean showFeedback,
+            @Nullable Map<String, Object> properties) {
         super(project);
         this.showFeedback = showFeedback;
         this.feedbackContext = feedbackContext;
         this.project = project;
-        this.properties = properties != null ? new HashMap<String, Object>(properties) : Collections.<String, Object>emptyMap();
+        this.properties = properties != null ? new HashMap<>(properties) : Collections.emptyMap();
 
         super.setTitle(title);
-        super.setOKButtonText(okButtonText);
+        if (okButtonText != null)
+            super.setOKButtonText(okButtonText);
         super.init();
     }
 


### PR DESCRIPTION
This dialog has no OK button and tries to pass null as a corresponding text. The setter method shouldn't be called in this case.

Closes #345.