### PR TITLE
Improve diagnostics for errors during scheduleUnversionedFilesForAddition call

### DIFF
--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSCheckinEnvironment.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSCheckinEnvironment.java
@@ -262,6 +262,7 @@ public class TFSCheckinEnvironment implements CheckinEnvironment {
                 exceptions.add(new VcsException(TfPluginBundle.message(TfPluginBundle.KEY_TFVC_ADD_ERROR, StringUtils.join(filesToAddPaths, ", "))));
             }
         } catch (RuntimeException e) {
+            logger.warn("Exception during adding the files", e);
             exceptions.add(new VcsException(e));
         }
         return exceptions;


### PR DESCRIPTION
One user has reported an issue when the Azure DevOps IntelliJ plugin keeps spamming them about "unversionedFiles is empty".

I've found that we lack diagnostics for cases when `AddCommand` was called from `TFSCheckinEnvironment::scheduleUnversionedFilesForAddition`: default VCS error reporting facility doesn't show or log the exception stack traces for this case.

As a first diagnostic step, let's write a warning to our logs for every exception thrown during this method execution.