### PR TITLE
New cache retention policy for runners created by FindWorkspaceCommand

### DIFF
--- a/plugin/src/com/microsoft/alm/plugin/external/ToolRunnerCache.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/ToolRunnerCache.java
@@ -15,11 +15,27 @@ import java.util.concurrent.ConcurrentMap;
 public class ToolRunnerCache {
     private static final Logger logger = LoggerFactory.getLogger(ToolRunnerCache.class);
 
-    private static ConcurrentMap<String, ToolRunner> cache = new ConcurrentHashMap<String, ToolRunner>(3);
+    private static final ConcurrentMap<String, ToolRunner> cache = new ConcurrentHashMap<>(3);
 
-    public static ToolRunner getRunningToolRunner(final String toolLocation, final ToolRunner.ArgumentBuilder argumentBuilder, final ToolRunner.Listener listener) {
-        logger.info("getRunningToolRunner: toolLocation={0}", toolLocation);
-        ToolRunner toolRunner = null;
+    /**
+     * Creates and returns a running tool runner instance for TFVC client.
+     *
+     * @param toolLocation              location of the tool to start.
+     * @param argumentBuilder           an object that defined the tool arguments.
+     * @param listener                  tool execution listener.
+     * @param shouldPrepareCachedRunner whether to prepare a new cached runner for the same location in advance: for
+     *                                  cases when new calls of the same tool in the same working directory are
+     *                                  likely. See {@link #getKey(String, ToolRunner.ArgumentBuilder)} for cache key
+     *                                  calculation algorithm.
+     * @return a started tool runner object.
+     */
+    public static ToolRunner getRunningToolRunner(
+            String toolLocation,
+            ToolRunner.ArgumentBuilder argumentBuilder,
+            ToolRunner.Listener listener,
+            boolean shouldPrepareCachedRunner) {
+        logger.info("getRunningToolRunner: toolLocation={}", toolLocation);
+        ToolRunner toolRunner;
 
         // Check the version
         final ToolVersion version = TfTool.getCachedVersion();
@@ -49,7 +65,8 @@ public class ToolRunnerCache {
 
             // Add another instance to the cache for later
             //TODO: clear all or part of the cache to make sure we aren't leaking memory by never cleaning up
-            updateCachedInstance(key, toolLocation, argumentBuilder);
+            if (shouldPrepareCachedRunner)
+                updateCachedInstance(key, toolLocation, argumentBuilder);
         }
 
         return toolRunner;

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
@@ -190,7 +190,7 @@ public abstract class Command<T> {
                         listener.progress("", OUTPUT_TYPE_INFO, 100);
                         listener.completed(result, error);
                     }
-                });
+                }, shouldPrepareCachedRunner());
     }
 
     /**
@@ -270,6 +270,21 @@ public abstract class Command<T> {
      */
     public int interpretReturnCode(final int returnCode) {
         return returnCode;
+    }
+
+    /**
+     * Determines whether a cached tool runner instance should be created after execution of this command. This runner
+     * will be used when a new command is issued against the same working directory/tool location. See
+     * {@link ToolRunnerCache#getKey} for details on cache key calculation.
+     * <p/>
+     * Usually, it is a good idea to prepare a runner in advance, because there's always a possibility that new
+     * commands will be issued against the same working directory as defined by the current command.
+     * <p/>
+     * It should be overridden in rare cases when it isn't necessary, e.g. when it is known that command is often used
+     * against temporary/non-workspace locations.
+     */
+    public boolean shouldPrepareCachedRunner() {
+        return true;
     }
 
     protected NodeList evaluateXPath(final String stdout, final String xpathQuery) {

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/FindWorkspaceCommand.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/FindWorkspaceCommand.java
@@ -77,6 +77,13 @@ public class FindWorkspaceCommand extends Command<Workspace> {
         return builder;
     }
 
+    @Override
+    public boolean shouldPrepareCachedRunner() {
+        // This command may be called on non-workspace location, so we shouldn't generally prepare a runner for the new
+        // workspace in advance. So, we should cache only "static" invocations with no working directory override.
+        return StringUtils.isEmpty(localPath);
+    }
+
     /**
      * Parses the output of the workfold command. (NOT XML)
      * SAMPLE

--- a/plugin/test/com/microsoft/alm/plugin/external/commands/FindWorkspaceCommandTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/external/commands/FindWorkspaceCommandTest.java
@@ -46,6 +46,12 @@ public class FindWorkspaceCommandTest extends AbstractCommandTest {
     }
 
     @Test
+    public void findWorkspaceCommandShouldOnlyBeCachedWithoutLocalPathDefined() {
+        Assert.assertFalse(new FindWorkspaceCommand("/tmp").shouldPrepareCachedRunner());
+        Assert.assertTrue(new FindWorkspaceCommand("collection", "workspace", null).shouldPrepareCachedRunner());
+    }
+
+    @Test
     public void testGetArgumentBuilder_collectionWorkspace() {
         final FindWorkspaceCommand cmd = new FindWorkspaceCommand("collectionName", "workspaceName", null);
         final ToolRunner.ArgumentBuilder builder = cmd.getArgumentBuilder();


### PR DESCRIPTION
This is mainly important for #325, but will decrease count of cached processes for old use cases, too.

The runners from `FindWorkspaceCommand` shouldn't generally be cached, because they may be called for a directory without TFVC workspace, and will just leak.

Closes #356.