### PR TITLE
Download ALM libraries from GitHub instead of relying on an old HTTP server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 plugins {
     id 'org.jetbrains.intellij' version '0.4.1' apply false
     id "org.jetbrains.kotlin.jvm" version "1.3.50" apply false
-    id "de.undercouch.download" version "4.0.0" apply false
+    id "de.undercouch.download" version "4.0.0"
 }
 
 /**
@@ -28,6 +28,8 @@ task wrapper(type: Wrapper) {
     distributionUrl = "https://services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
 }
 
+apply from: 'dependencies.gradle'
+
 def mainProjects = [project(":L2Tests"), project(":plugin"), project(':plugin:test-utils')]
 
 /**
@@ -35,13 +37,10 @@ def mainProjects = [project(":L2Tests"), project(":plugin"), project(':plugin:te
  */
 allprojects {
     repositories {
+        flatDir {
+            dirs externalDependenciesDirectory
+        }
         mavenCentral()
-        maven {
-            url "http://artifacts.eastus.cloudapp.azure.com:8081/nexus/content/repositories/snapshots"
-        }
-        maven {
-            url "http://artifacts.eastus.cloudapp.azure.com:8081/nexus/content/repositories/releases"
-        }
         maven {
             url "https://cache-redirector.jetbrains.com/www.myget.org/F/rd-snapshots/maven"
         }
@@ -65,7 +64,6 @@ configure(mainProjects) {
     apply plugin: 'checkstyle'
     apply plugin: 'pmd'
     apply plugin: 'findbugs'
-
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
@@ -190,8 +188,20 @@ project(":L2Tests") {
  */
 configure(mainProjects) {
     dependencies {
+        // Dependencies of ':com.microsoft.alm.client:0.4.3-SNAPSHOT'
+        compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
+        compile 'commons-codec:commons-codec:1.10'
+        compile 'com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.4.1'
+
+        // Microsoft ALM libraries that are managed by the dependencies.gradle script
+        compile ':com.microsoft.alm.client:0.4.3-SNAPSHOT'
+        compile ':com.microsoft.alm.client.build2:0.4.3-SNAPSHOT'
+        compile ':com.microsoft.alm.client.core:0.4.3-SNAPSHOT'
+        compile ':com.microsoft.alm.client.distributedtask:0.4.3-SNAPSHOT'
+        compile ':com.microsoft.alm.client.sourcecontrol:0.4.3-SNAPSHOT'
+        compile ':com.microsoft.alm.client.workitemtracking:0.4.3-SNAPSHOT'
+
         codeAnalysisLibs 'com.google.code.findbugs:annotations:3.0.0'
-        compile group: 'com.microsoft.alm', name: 'alm-http-client-dep', version: '0.4.3-SNAPSHOT'
         compile group: 'commons-io', name: 'commons-io', version: '2.4'
         compile group: 'org.glassfish.jersey.core', name: 'jersey-client', version: '2.28'
         compile group: 'org.glassfish.jersey.connectors', name: 'jersey-apache-connector', version: '2.28'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+/**
+ * This file controls the Microsoft ALM dependency artifacts that should be downloaded before building the plugin.
+ */
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.security.MessageDigest
+
+ext {
+    externalDependenciesDirectory = "$buildDir/externalDependencies"
+}
+
+def externalDependencies = [
+    'https://github.com/JetBrains/vso-httpclient-java/releases/download/0.4.3-SNAPSHOT/com.microsoft.alm.client-0.4.3-SNAPSHOT.jar': '5a86232de6ca24f41b74e5582ee0cb0c73a031ccb7a889b7d95a77fe1670555d',
+    'https://github.com/JetBrains/vso-httpclient-java/releases/download/0.4.3-SNAPSHOT/com.microsoft.alm.client.build2-0.4.3-SNAPSHOT.jar': '938ba642439a40d242106f51f1d81e8db4b92c6245e05f600da5554e7056d211',
+    'https://github.com/JetBrains/vso-httpclient-java/releases/download/0.4.3-SNAPSHOT/com.microsoft.alm.client.core-0.4.3-SNAPSHOT.jar': 'dc39f877f8360d46420b9056742c58be6f85c2724212d783c183fd9cca36fb7a',
+    'https://github.com/JetBrains/vso-httpclient-java/releases/download/0.4.3-SNAPSHOT/com.microsoft.alm.client.distributedtask-0.4.3-SNAPSHOT.jar': '5cb95c0adf5e64d6d7e0dc4750f81480566de4c30ba15cd470cb1e1cf9e1b48e',
+    'https://github.com/JetBrains/vso-httpclient-java/releases/download/0.4.3-SNAPSHOT/com.microsoft.alm.client.sourcecontrol-0.4.3-SNAPSHOT.jar': '73be5b93e7b0f7e03f37e2c79481a1eeebf14b1bd4e475f7757cb1188aa42a85',
+    'https://github.com/JetBrains/vso-httpclient-java/releases/download/0.4.3-SNAPSHOT/com.microsoft.alm.client.workitemtracking-0.4.3-SNAPSHOT.jar': '6596b047be73f5e979c42cdaf548f93235b477e6b15782ab4faace3f7c7a4c23'
+]
+
+private static def getUrlFileName(String url) {
+    return Paths.get(new URI(url).getPath()).fileName
+}
+
+externalDependencies.entrySet().forEach { entry ->
+    def url = entry.key
+    def expectedHash = entry.value
+    def fileName = getUrlFileName(url)
+    def downloadedFilePath = "$ext.externalDependenciesDirectory/$fileName"
+    download {
+        src url
+        dest downloadedFilePath
+        overwrite false
+    }
+
+    def digest = MessageDigest.getInstance("SHA-256")
+    def bytes = Files.readAllBytes(Paths.get(downloadedFilePath))
+    def hash = String.format("%064x", new BigInteger(1, digest.digest(bytes)))
+    if (!hash.equalsIgnoreCase(expectedHash)) {
+        delete downloadedFilePath
+        throw new RuntimeException("Expected hash: $expectedHash, actual hash: $hash for dependency file $fileName\nPlease retry build")
+    }
+}

--- a/plugin/test/com/microsoft/alm/plugin/idea/git/ui/simplecheckout/SimpleCheckoutControllerTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/git/ui/simplecheckout/SimpleCheckoutControllerTest.java
@@ -5,6 +5,7 @@ package com.microsoft.alm.plugin.idea.git.ui.simplecheckout;
 
 import com.intellij.openapi.ui.ValidationInfo;
 import com.microsoft.alm.plugin.idea.IdeaAbstractTest;
+import com.microsoft.alm.plugin.idea.common.resources.TfPluginBundle;
 import com.microsoft.alm.plugin.idea.common.ui.common.BaseDialog;
 import com.microsoft.alm.plugin.idea.common.ui.common.ModelValidationInfo;
 import org.junit.Assert;
@@ -50,7 +51,7 @@ public class SimpleCheckoutControllerTest extends IdeaAbstractTest {
     }
 
     @Test
-    public void testActionPerformed() throws Exception {
+    public void testActionPerformed() {
         ActionEvent e = new ActionEvent(this, 1, BaseDialog.CMD_OK);
         controller.actionPerformed(e);
 
@@ -85,13 +86,14 @@ public class SimpleCheckoutControllerTest extends IdeaAbstractTest {
 
     @Test
     public void testValidate_Error() {
-        String message = "message";
+        String messageKey = TfPluginBundle.KEY_VCS_LOADING_ERRORS;
+        String message = TfPluginBundle.message(messageKey);
         String componentName = "component";
         JComponent mockComponent = mock(JComponent.class);
 
         when(mockDialog.getComponent(componentName)).thenReturn(mockComponent);
-        ValidationInfo expectInfo = new ValidationInfo("!" + message + "!", mockComponent);
-        when(mockModel.validate()).thenReturn(ModelValidationInfo.createWithResource(componentName, message));
+        ValidationInfo expectInfo = new ValidationInfo(message, mockComponent);
+        when(mockModel.validate()).thenReturn(ModelValidationInfo.createWithResource(componentName, messageKey));
         ValidationInfo actualInfo = controller.validate();
 
         Assert.assertEquals(expectInfo.message, actualInfo.message);


### PR DESCRIPTION
This PR removes our dependency on an internal artifact repository only available via HTTP. We'll download the same artifacts (available as open-source) from GitHub releases.

Also, I've fixed a test issue that caused one of the test runs to fail.