### PR TITLE
Share lifetime between host, protocol and connection

### DIFF
--- a/plugin/src/com/microsoft/alm/plugin/external/reactive/Lifetimes.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/reactive/Lifetimes.java
@@ -5,12 +5,11 @@ package com.microsoft.alm.plugin.external.reactive;
 
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.util.Disposer;
-import com.jetbrains.rd.util.lifetime.Lifetime;
 import com.jetbrains.rd.util.lifetime.LifetimeDefinition;
 import com.jetbrains.rd.util.lifetime.LifetimeStatus;
 
 public class Lifetimes {
-    public static Lifetime defineNestedLifetime(Disposable disposable) {
+    public static LifetimeDefinition defineNestedLifetime(Disposable disposable) {
         LifetimeDefinition lifetimeDefinition = new LifetimeDefinition();
         Disposer.register(disposable, () -> {
             if (lifetimeDefinition.getStatus() == LifetimeStatus.Alive)

--- a/plugin/src/com/microsoft/alm/plugin/external/reactive/ReactiveTfvcClientHost.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/reactive/ReactiveTfvcClientHost.java
@@ -19,6 +19,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.SystemInfo;
 import com.jetbrains.rd.framework.impl.RdSecureString;
+import com.jetbrains.rd.util.lifetime.LifetimeDefinition;
 import com.jetbrains.rd.util.threading.SingleThreadScheduler;
 import com.microsoft.alm.plugin.authentication.AuthenticationInfo;
 import com.microsoft.alm.plugin.external.models.ExtendedItemInfo;
@@ -64,15 +65,18 @@ public class ReactiveTfvcClientHost {
 
     private static final Logger ourLogger = Logger.getInstance(ReactiveTfvcClientHost.class);
 
+    private final LifetimeDefinition myLifetime;
     private final ReactiveClientConnection myConnection;
 
-    public ReactiveTfvcClientHost(ReactiveClientConnection connection) {
+    public ReactiveTfvcClientHost(LifetimeDefinition myLifetime, ReactiveClientConnection connection) {
+        this.myLifetime = myLifetime;
         myConnection = connection;
     }
 
     public static ReactiveTfvcClientHost create(Disposable parent, Path clientPath) throws ExecutionException {
-        SingleThreadScheduler scheduler = new SingleThreadScheduler(defineNestedLifetime(parent), "ReactiveTfClient Scheduler");
-        ReactiveClientConnection connection = new ReactiveClientConnection(scheduler);
+        LifetimeDefinition hostLifetime = defineNestedLifetime(parent);
+        SingleThreadScheduler scheduler = new SingleThreadScheduler(hostLifetime, "ReactiveTfClient Scheduler");
+        ReactiveClientConnection connection = new ReactiveClientConnection(hostLifetime, scheduler);
         try {
             Path logDirectory = Paths.get(PathManager.getLogPath(), "ReactiveTfsClient");
             Path clientHomeDir = clientPath.getParent().getParent();
@@ -81,18 +85,18 @@ public class ReactiveTfvcClientHost {
             ProcessHandler processHandler = new OSProcessHandler(commandLine);
             connection.getLifetime().onTerminationIfAlive(processHandler::destroyProcess);
 
-            processHandler.addProcessListener(createProcessListener(connection));
+            processHandler.addProcessListener(createProcessListener(hostLifetime));
             processHandler.startNotify();
 
-            return new ReactiveTfvcClientHost(connection);
+            return new ReactiveTfvcClientHost(hostLifetime, connection);
         } catch (Throwable t) {
-            connection.terminate();
+            hostLifetime.terminate(false);
             throw t;
         }
     }
 
     public void terminate() {
-        myConnection.terminate();
+        myLifetime.terminate(false);
     }
 
     @NotNull
@@ -216,7 +220,7 @@ public class ReactiveTfvcClientHost {
                 .thenCompose(collection -> myConnection.renameFileAsync(collection, oldPath, newPath));
     }
 
-    private static ProcessListener createProcessListener(ReactiveClientConnection connection) {
+    private static ProcessListener createProcessListener(LifetimeDefinition lifetime) {
         return new ProcessAdapter() {
             @Override
             public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
@@ -232,7 +236,7 @@ public class ReactiveTfvcClientHost {
             @Override
             public void processTerminated(@NotNull ProcessEvent event) {
                 ourLogger.info("Process is terminated, terminating the connection");
-                connection.terminate();
+                lifetime.terminate(false);
             }
         };
     }


### PR DESCRIPTION
This will allow us to get rid of errors when closing a project. Earlier, there was guaranteed exception on project close, because protocol disconnection was de-synchronized with the host lifetime:
```
Catch: Task com.jetbrains.rd.util.threading.SingleThreadSchedulerBase$queue$1@9f471b8 rejected from com.jetbrains.rd.util.threading.SingleThreadSchedulerBase$executor$1@357414b4[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 15]
java.util.concurrent.RejectedExecutionException: Task com.jetbrains.rd.util.threading.SingleThreadSchedulerBase$queue$1@9f471b8 rejected from com.jetbrains.rd.util.threading.SingleThreadSchedulerBase$executor$1@357414b4[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 15]
	at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2047)
	at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:823)
	at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1369)
	at com.jetbrains.rd.util.threading.SingleThreadSchedulerBase.queue(SingleThreadScheduler.kt:38)
	at com.jetbrains.rd.framework.SocketWire$Base$1.invoke(SocketWire.kt:104)
	at com.jetbrains.rd.framework.SocketWire$Base$1.invoke(SocketWire.kt:65)
	at com.jetbrains.rd.util.reactive.Signal.fire(Signal.kt:29)
	at com.jetbrains.rd.util.reactive.OptProperty.set(Property.kt:33)
	at com.jetbrains.rd.framework.SocketWire$Server$thread$1.invoke(SocketWire.kt:369)
	at com.jetbrains.rd.framework.SocketWire$Server$thread$1.invoke(SocketWire.kt:338)
	at kotlin.concurrent.ThreadsKt$thread$thread$1.run(Thread.kt:30)
```

Now, there's a single lifetime controlling all these coupled components, and they all are always synchronized.