### PR TITLE
Avoid scheduling file addition if there's no files to add

### DIFF
--- a/plugin/resources/META-INF/plugin.xml
+++ b/plugin/resources/META-INF/plugin.xml
@@ -63,6 +63,7 @@
         <li>Add operations are now performed using faster reactive client (<a href="https://github.com/microsoft/azure-devops-intellij/issues/338">#338</a>)</li>
         <li>Rename operations are now performed using faster reactive client</li>
         <li><b>Merge Branch Changes</b> action won't stay in your way in non-TFVC projects in the plugin in installed</li>
+        <li>Avoid spamming "unversionedFiles are empty" message when trying to add files in some cases</li>
       </ul>
       <br />
     ]]>

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileListener.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileListener.java
@@ -155,6 +155,11 @@ public class TFSFileListener extends VcsVFSListener {
 
     @Override
     protected void performAdding(@NotNull final Collection<VirtualFile> addedFiles, @NotNull final Map<VirtualFile, VirtualFile> copyFromMap) {
+        if (addedFiles.isEmpty()) {
+            logger.warn("TFSFileListener was asked to add 0 files under VCS; skipping");
+            return;
+        }
+
         final List<VcsException> errors = new ArrayList<>();
         ProgressManager.getInstance().runProcessWithProgressSynchronously(() -> {
             ProgressManager.getInstance().getProgressIndicator().setIndeterminate(true);


### PR DESCRIPTION
This PR is continuation of #352.

It removes the message "unversionedFiles is empty" being continuously spammed in some situations (e.g. when a file with dollar in its name is changed regularly).