### PR TITLE
Fix error messages on TFVC repository import

### DIFF
--- a/plugin/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
+++ b/plugin/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
@@ -406,7 +406,7 @@ Tfvc.Checkin.Successful.Msg=Successfully created {0}
 Tfvc.Checkin.Link.Text=Changeset #{0}
 Tfvc.Checkin.Status=Checking in files...
 Tfvc.Notification.FileNameStartsWithDollar=File name starts with '$', TFVC client will not work properly until this file is ignored\: {0}
-Tfvc.RepositoryImportError=Couldn't create TFVC repository in {0}
+Tfvc.RepositoryImportError=Couldn''t create TFVC repository in {0}
 Tfvc.RepositoryImportSuccess=Created TFVC repository in {0}
 Tfvc.Update.Status.Msg=Updating files...
 Tfvc.tf.VersionWarning.Progress=Checking the version of the TF command line...
@@ -547,7 +547,7 @@ Tfvc.RepositoryView.Changelist.Title=Changelist
 Tfvc.RepositoryView.Column.Revision=Revision
 
 # Visual Studio Client
-VisualStudioClient.AuthenticationError=Visual Studio TFVC client has reported that authentication is required to access a workspace under path "{0}". This requires manual workspace import. Please see the documentation for details: https://rider-support.jetbrains.com/hc/en-us/articles/360000335099-How-to-use-Visual-Studio-s-TFV%D0%A1-local-workspace-in-Rider
+VisualStudioClient.AuthenticationError=Visual Studio TFVC client has reported that authentication is required to access a workspace under path "{0}". This requires manual workspace import. Please see the documentation for details: https://rider-support.jetbrains.com/hc/en-us/articles/360000335099
 VisualStudioClient=Visual Studio TFVC Client
 
 #KEEP FORMS AT THE BOTTOM (this is where the designer will add items)


### PR DESCRIPTION
- `Tfvc.RepositoryImportError` has unescaped `'` which breaks `MessageFormat`-based string formatting
- `VisualStudioClient.AuthenticationError` support article link was unnecessarily long (and included a Cyrillic "С")