### PR TITLE
Update supported IntelliJ version range to 2019.1–2020.2

### DIFF
--- a/L2Tests/test/com/microsoft/alm/L2/L2Test.java
+++ b/L2Tests/test/com/microsoft/alm/L2/L2Test.java
@@ -7,9 +7,6 @@ import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.openapi.vcs.VcsConfiguration;
-import com.intellij.openapi.vcs.changes.ChangeListManager;
-import com.intellij.openapi.vcs.changes.VcsDirtyScopeManager;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.testFramework.EdtTestUtil;
@@ -257,8 +254,6 @@ public abstract class L2Test extends UsefulTestCase {
             myVcs = ObjectUtils.assertNotNull(GitVcs.getInstance(myProject));
             myVcs.doActivate();
 
-            addSilently();
-            removeSilently();
             EULADialog.acceptClientEula();
             ServerPollingManager.getInstance().startPolling();
         } catch (Exception e) {
@@ -376,6 +371,7 @@ public abstract class L2Test extends UsefulTestCase {
         return Collections.emptyList();
     }
 
+    @SuppressWarnings("UnstableApiUsage") // TODO: Replace with defaultRunBare(ThrowableRunnable<Throwable>) after update to IDEA 2020.3
     @Override
     protected void defaultRunBare() throws Throwable {
         try {
@@ -391,24 +387,6 @@ public abstract class L2Test extends UsefulTestCase {
     @NotNull
     private String createTestStartedIndicator() {
         return "Starting " + getClass().getName() + "." + getTestName(false) + Math.random();
-    }
-
-    protected void doActionSilently(final VcsConfiguration.StandardConfirmation op) {
-        //AbstractVcsTestCase.setStandardConfirmation(myProject, GitVcs.NAME, op, VcsShowConfirmationOption.Value.DO_ACTION_SILENTLY);
-    }
-
-    protected void updateChangeListManager() {
-        ChangeListManager changeListManager = ChangeListManager.getInstance(myProject);
-        VcsDirtyScopeManager.getInstance(myProject).markEverythingDirty();
-        changeListManager.ensureUpToDate(false);
-    }
-
-    protected void addSilently() {
-        doActionSilently(VcsConfiguration.StandardConfirmation.ADD);
-    }
-
-    protected void removeSilently() {
-        doActionSilently(VcsConfiguration.StandardConfirmation.REMOVE);
     }
 
     public static File createTempDirectory()

--- a/L2Tests/test/com/microsoft/alm/L2/git/L2GitUtil.java
+++ b/L2Tests/test/com/microsoft/alm/L2/git/L2GitUtil.java
@@ -57,7 +57,7 @@ public class L2GitUtil {
         final LocalChangeListImpl localChangeList = LocalChangeListImpl.createEmptyChangeListImpl(project, "TestCommit", "12345");
         final ChangeListManagerImpl changeListManager = ChangeListManagerImpl.getInstanceImpl(project);
         VcsDirtyScopeManager.getInstance(project).markEverythingDirty();
-        changeListManager.ensureUpToDate(false);
+        changeListManager.ensureUpToDate();
         changeListManager.addUnversionedFiles(localChangeList, ImmutableList.of(readmeVirtualFile));
         final Change change = changeListManager.getChange(LocalFileSystem.getInstance().findFileByIoFile(file));
         repository.getVcs().getCheckinEnvironment().commit(ImmutableList.of(change), COMMIT_MESSAGE);

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a plugin for working with Git and TFVC repositories on Azure DevOps and Team Foundation Server (TFS) 2015+ inside IntelliJ, Android Studio, 
 and various other JetBrains IDEs. It is supported on Linux, Mac OS X, and Windows.
-It is compatible with IntelliJ IDEA Community and Ultimate editions (version 2018.3+) and Android Studio (version 3.4+).
+It is compatible with IntelliJ IDEA Community and Ultimate editions (version 2019.1+) and Android Studio (version 3.5+).
 
 To learn more about installing and using our Azure DevOps IntelliJ plug-in, visit: https://docs.microsoft.com/en-us/azure/devops/java/download-intellij-plug-in
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 buildNumber=1.161.0
-ideaVersion=2018.3
+ideaVersion=2019.1
 
 kotlin.code.style=official

--- a/plugin/resources/META-INF/plugin.xml
+++ b/plugin/resources/META-INF/plugin.xml
@@ -47,7 +47,7 @@
       <br />
       <i>Compiled with Java 8</i>
       <br />
-      <i>Compatible with IntelliJ Ultimate and Community editions versions 2018.3 and later and Android Studio 3.4 and later</i>
+      <i>Compatible with IntelliJ Ultimate and Community editions versions 2019.1 and later and Android Studio 3.5 and later</i>
       <br />
       <br />
       <b>End User License Agreement & Privacy Policy</b>

--- a/plugin/src/com/microsoft/alm/plugin/external/reactive/ReactiveTfvcClientHolder.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/reactive/ReactiveTfvcClientHolder.java
@@ -29,8 +29,6 @@ public class ReactiveTfvcClientHolder implements Disposable {
     }
 
     public static Path getClientBackendPath() {
-        // TODO: Replace with PluginManagerCore.getPlugin after migration to IDEA 2019.3
-        //noinspection UnstableApiUsage
         return Paths.get(
                 Objects.requireNonNull(PluginManager.getPlugin(IdeaHelper.PLUGIN_ID)).getPath().getAbsolutePath(),
                 "backend");

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/SingleItemAction.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/SingleItemAction.java
@@ -121,7 +121,7 @@ public abstract class SingleItemAction extends DumbAwareAction {
                 || !getAllowedStatuses().contains(FileStatusManager.getInstance(project).getStatus(file)))
             return false;
 
-        // TODO: Remove this suppression after migration to IDEA 2019.1. AbstractVcs became non-generic in newer IDEA.
+        // TODO: Remove this suppression after migration to IDEA 2019.3. AbstractVcs became non-generic in newer IDEA.
         @SuppressWarnings("rawtypes") AbstractVcs vcs = VcsUtil.getVcsFor(project, file);
         return vcs != null && TFSVcs.getKey().equals(vcs.getKeyInstanceMethod());
     }

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TfvcIntegrationEnabler.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TfvcIntegrationEnabler.java
@@ -64,16 +64,14 @@ public class TfvcIntegrationEnabler extends VcsIntegrationEnabler {
         myVcs = vcs;
     }
 
-    // TODO: Fix the generic signatures in this method after migration to IDEA 2019.1. Currently this is crippled due to
-    // IDEA 2018.3 compatibility.
-    @SuppressWarnings("unchecked")
     @Override
-    public void enable(@NotNull Collection vcsRoots) {
+    public void enable(@NotNull Collection<? extends VcsRoot> vcsRoots) {
         // This override does the same as base method, but tries to determine a workspace directory instead of using
         // project.getBaseDir().
-        Collection<VcsRoot> typedRoots = (Collection<VcsRoot>)vcsRoots;
-        Collection<VirtualFile> existingRoots = typedRoots.stream().filter(root -> {
-            AbstractVcs vcs = root.getVcs();
+        Collection<VirtualFile> existingRoots = vcsRoots.stream().filter(root -> {
+            // TODO: Remove this suppression after migration to IDEA 2019.3. AbstractVcs became non-generic in newer
+            // IDEA.
+            @SuppressWarnings("rawtypes") AbstractVcs vcs = root.getVcs();
             return vcs != null && vcs.getName().equals(myVcs.getName());
         }).map(VcsRoot::getPath).collect(toList());
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/tfignore/TfIgnoreLanguage.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/tfignore/TfIgnoreLanguage.java
@@ -5,7 +5,7 @@ package com.microsoft.alm.plugin.idea.tfvc.tfignore;
 
 import com.intellij.lang.Language;
 
-public class TfIgnoreLanguage extends Language { // TODO: Inherit from IgnoreLanguage if we target IDEA 2019.*
+public class TfIgnoreLanguage extends Language {
     public static TfIgnoreLanguage INSTANCE = new TfIgnoreLanguage();
     private TfIgnoreLanguage() {
         super("TFIgnore");

--- a/plugin/test/com/microsoft/alm/plugin/idea/common/ui/common/mocks/MockServerContextLookupPageModel.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/common/ui/common/mocks/MockServerContextLookupPageModel.java
@@ -6,6 +6,8 @@ package com.microsoft.alm.plugin.idea.common.ui.common.mocks;
 import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.idea.common.ui.common.ModelValidationInfo;
 import com.microsoft.alm.plugin.idea.common.ui.common.ServerContextLookupPageModel;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import sun.security.util.Debug;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +44,8 @@ public class MockServerContextLookupPageModel implements ServerContextLookupPage
 
     @Override
     public void clearContexts() {
+        // Disgnostics for ServerContextLookupListenerTest::testLoadContexts
+        Debug.println("MockServerContextLookupPageModel::clearContexts", ExceptionUtils.getStackTrace(new Throwable()));
         contexts.clear();
     }
 }

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -101,5 +101,5 @@ jobs:
         displayName: Gradle compile
         inputs:
           jdkVersionOption: 1.8
-          options: '--info -PideaVersion=2020.1'
+          options: '--info -PideaVersion=2020.2'
           tasks: :plugin:compileJava


### PR DESCRIPTION
Since Android Studio 3.5 has been released in August, 2019, we could now update to Android Studio 3.5+ and IntelliJ IDEA 2019.1+.

Also, IntelliJ IDEA 2020.2 has been recently released, so we could update our compatibility tests to include it, too.

I've reviewed all the comments mentioning IDEA 2018 or IDEA 2019, and fixed the issues that should be fixed, and removed the outdated ones.