### PR TITLE
Fix a flaky ServerContextLookupListenerTest::testLoadContexts

### DIFF
--- a/plugin/test/com/microsoft/alm/plugin/idea/common/ui/common/mocks/MockServerContextLookupOperation.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/common/ui/common/mocks/MockServerContextLookupOperation.java
@@ -40,6 +40,11 @@ public class MockServerContextLookupOperation extends ServerContextLookupOperati
     }
 
     @Override
+    public void doWork(Inputs inputs) {
+        // Do nothing (all the results are supposed to be provided by the test, no need to run actual work).
+    }
+
+    @Override
     protected void onLookupResults(Results results) {
         super.onLookupResults(results);
     }

--- a/plugin/test/com/microsoft/alm/plugin/idea/common/ui/common/mocks/MockServerContextLookupPageModel.java
+++ b/plugin/test/com/microsoft/alm/plugin/idea/common/ui/common/mocks/MockServerContextLookupPageModel.java
@@ -6,8 +6,6 @@ package com.microsoft.alm.plugin.idea.common.ui.common.mocks;
 import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.idea.common.ui.common.ModelValidationInfo;
 import com.microsoft.alm.plugin.idea.common.ui.common.ServerContextLookupPageModel;
-import org.apache.commons.lang3.exception.ExceptionUtils;
-import sun.security.util.Debug;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,8 +42,6 @@ public class MockServerContextLookupPageModel implements ServerContextLookupPage
 
     @Override
     public void clearContexts() {
-        // Disgnostics for ServerContextLookupListenerTest::testLoadContexts
-        Debug.println("MockServerContextLookupPageModel::clearContexts", ExceptionUtils.getStackTrace(new Throwable()));
         contexts.clear();
     }
 }


### PR DESCRIPTION
Turns out the `MockServerContextLookupOperation` was asynchronously calling the same methods we're manually calling in this test, so there was a race between the body of the test method and `ServerContextLookupOperation::doWork`.