### PR TITLE
Do not require "TeamServicesUrl" for SSH to HTTPS conversion

### DIFF
--- a/plugin/src/com/microsoft/alm/common/utils/UrlHelper.java
+++ b/plugin/src/com/microsoft/alm/common/utils/UrlHelper.java
@@ -218,7 +218,7 @@ public class UrlHelper {
     }
 
     public static boolean isSshGitRemoteUrl(final String gitRemoteUrl) {
-        if (isGitRemoteUrl(gitRemoteUrl) && isTeamServicesUrl(gitRemoteUrl)) {
+        if (isGitRemoteUrl(gitRemoteUrl)) {
             if (StringUtils.startsWithIgnoreCase(gitRemoteUrl, "https://") ||
                     StringUtils.startsWithIgnoreCase(gitRemoteUrl, "http://")) {
                 return false;

--- a/plugin/test/com/microsoft/alm/common/utils/UrlHelperTest.java
+++ b/plugin/test/com/microsoft/alm/common/utils/UrlHelperTest.java
@@ -256,6 +256,9 @@ public class UrlHelperTest {
         assertEquals("https://myorganization.visualstudio.com/myCollection/_git/My.Repo",
                 UrlHelper.getHttpsGitUrlFromSshUrl("https://myorganization.visualstudio.com/myCollection/_git/My.Repo"));
 
+        assertEquals("https://azure.devops.server.com/tfs/myCollection/_git/My.Repo",
+                UrlHelper.getHttpsGitUrlFromSshUrl("ssh://azure.devops.server.com:22/tfs/myCollection/_git/My.Repo"));
+
         assertNull(UrlHelper.getHttpsGitUrlFromSshUrl("ssh://git@github.com:Microsoft/vso-agent-tasks.git"));
 
         assertNull(UrlHelper.getHttpsGitUrlFromSshUrl("git@github.com:Microsoft/vso-agent-tasks.git"));


### PR DESCRIPTION
I think we don't need a check for TeamServicesUrl, so this will work for on premise deployments of ADS
#351 
#176 