### PR TITLE
TFSContentRevision: fix issue with history view

### DIFF
--- a/plugin/resources/META-INF/plugin.xml
+++ b/plugin/resources/META-INF/plugin.xml
@@ -41,6 +41,7 @@
         <li>Check the build status of your repository and queue a new build if desired.</li>
         <li>Supports proxy settings configured in the IDE's System Settings section.</li>
         <li>Edit cached project information through configuration management.</li>
+        <li>History view: fixed an issue where we were always performing a diff operation on the local file version.</li>
       </ul>
       <br />
       <br />

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/revision/TFSContentRevision.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/revision/TFSContentRevision.java
@@ -132,14 +132,15 @@ public abstract class TFSContentRevision implements ContentRevision {
     @Nullable
     public String getContent() throws VcsException {
         FilePath filePath = getFile();
+        TFSContentStore contentStore;
         try {
             // Download the file if required:
-            TFSContentStoreFactory.findOrCreate(filePath.getPath(), getChangeset(), getFilePath(), project);
+            contentStore = TFSContentStoreFactory.findOrCreate(filePath.getPath(), getChangeset(), getFilePath(), project);
         } catch (IOException e) {
             throw new VcsException(e);
         }
 
-        VirtualFile virtualFile = Objects.requireNonNull(filePath.getVirtualFile());
+        VirtualFile virtualFile = Objects.requireNonNull(VfsUtil.findFileByIoFile(contentStore.getTmpFile(), true));
         try {
             return VfsUtil.loadText(virtualFile);
         } catch (IOException e) {


### PR DESCRIPTION
Previously, we were always doing diff on the local version of the file.