### PR TITLE
#491: ChangesBrowser NoClassDefFoundError

### DIFF
--- a/plugin/src/com/microsoft/alm/plugin/idea/git/ui/pullrequest/CreatePullRequestForm.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/ui/pullrequest/CreatePullRequestForm.java
@@ -6,7 +6,7 @@ package com.microsoft.alm.plugin.idea.git.ui.pullrequest;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vcs.changes.Change;
-import com.intellij.openapi.vcs.changes.ui.ChangesBrowser;
+import com.intellij.openapi.vcs.changes.ui.SimpleChangesBrowser;
 import com.intellij.uiDesigner.core.GridConstraints;
 import com.intellij.uiDesigner.core.GridLayoutManager;
 import com.intellij.util.ui.JBUI;
@@ -214,8 +214,8 @@ public class CreatePullRequestForm implements BasicForm {
 
     private JComponent createDiffPaneBrowser(final Project project, final GitCommitCompareInfo compareInfo) {
         List<Change> diff = compareInfo.getTotalDiff();
-        final ChangesBrowser changesBrowser = new ChangesBrowser(project, null, diff, null, false, true,
-                null, ChangesBrowser.MyUseCase.COMMITTED_CHANGES, null);
+        final SimpleChangesBrowser changesBrowser = new  SimpleChangesBrowser(project,diff);
+
         changesBrowser.setChangesToDisplay(diff);
         return changesBrowser;
     }


### PR DESCRIPTION
Migration from deprecated ChangesBrowser to SimpleChangesBrowser  as per
[… (https://plugins.jetbrains.com/docs/intellij/api-changes-list-2022.html#20223)](https://plugins.jetbrains.com/docs/intellij/api-changes-list-2022.html#20223)

Fixes #491 