### PR TITLE
Fix for #498

### DIFF
--- a/plugin/resources/META-INF/plugin.xml
+++ b/plugin/resources/META-INF/plugin.xml
@@ -59,10 +59,7 @@
     <change-notes><![CDATA[
       <br />
       <ul>
-        <li>Bump the minimal supported IntelliJ version to 2019.3.</li>
-        <li>Fix encoding issues when browsing the local diff (<a href="https://github.com/microsoft/azure-devops-intellij/issues/451">#451</a>).</li>
-        <li>Rework TFVC VCS root detection to use currently active TFVC client (i.e. it is able to use the reactive client which is much faster).</li>
-        <li>Enable the reactive TFVC client by default.</li>
+        <li>Fix an issue when it was impossible to create a pull request in IDEs based on IntelliJ 2022.2</li>
       </ul>
       <br />
     ]]>

--- a/plugin/resources/META-INF/plugin.xml
+++ b/plugin/resources/META-INF/plugin.xml
@@ -59,7 +59,8 @@
     <change-notes><![CDATA[
       <br />
       <ul>
-        <li>Fix an issue when it was impossible to create a pull request in IDEs based on IntelliJ 2022.2</li>
+        <li>Fix an issue <a href="https://github.com/microsoft/azure-devops-intellij/issues/491">#491</a>: it was impossible to create a Git pull request in IDEs based on IntelliJ 2022.2</li>
+        <li>Fix an issue with TFVC operations (<a href="https://github.com/microsoft/azure-devops-intellij/issues/498">#498</a>).</li>
       </ul>
       <br />
     ]]>

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
@@ -20,7 +20,6 @@ import com.microsoft.alm.plugin.external.utils.WorkspaceHelper;
 import com.microsoft.tfs.model.connector.TfsLocalPath;
 import com.microsoft.tfs.model.connector.TfsServerPath;
 import com.microsoft.tfs.model.connector.TfsWorkspaceMapping;
-import com.sun.org.apache.xpath.internal.jaxp.XPathFactoryImpl;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -35,6 +34,7 @@ import sun.security.util.Debug;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -314,7 +314,7 @@ public abstract class Command<T> {
             xmlInput = new InputSource(new StringReader(stdout));
         }
 
-        final XPath xpath = new XPathFactoryImpl().newXPath();
+        final XPath xpath = XPathFactory.newInstance().newXPath();
         try {
             final Object result = xpath.evaluate(xpathQuery, xmlInput, XPathConstants.NODESET);
             if (result != null && result instanceof NodeList) {


### PR DESCRIPTION
Turns out that direct using of `XPathFactoryImpl` introduced in #289 wasn't a good idea for newer Java runtimes.

I cannot reproduce the original issue with this fix, so I think it's good to go. All the tests are green.