### PR TITLE
EULA: update the service code to avoid deadlocks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,6 +143,11 @@ project(":plugin") {
     }
 
     task zip(dependsOn: ['buildPlugin','test']) {}
+
+    // Uncomment for IDE internal mode:
+    //runIde {
+    //    jvmArgs("-Didea.is.intenal=true")
+    //}
 }
 
 project(':plugin:test-utils') {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-buildNumber=1.162.1
+buildNumber=1.162.2
 ideaVersion=2021.2.4
 
 kotlin.code.style=official

--- a/plugin/resources/META-INF/plugin.xml
+++ b/plugin/resources/META-INF/plugin.xml
@@ -59,12 +59,7 @@
     <change-notes><![CDATA[
       <br />
       <ul>
-        <li>Minimal supported IntelliJ platform version is now 2021.2.4.</li>
-        <li>Fixed an issue <a href="https://github.com/microsoft/azure-devops-intellij/issues/473">#473</a>: it was impossible to show the conflict resolve dialog for TFVC.</li>
-        <li>Fixed an issue <a href="https://github.com/microsoft/azure-devops-intellij/issues/491">#491</a>: it was impossible to create a Git pull request in IDEs based on IntelliJ 2022.2</li>
-        <li>Fixed an issue with TFVC operations (<a href="https://github.com/microsoft/azure-devops-intellij/issues/498">#498</a>).</li>
-        <li>TFS SDK is upgraded to <a href="https://github.com/JetBrains/team-explorer-everywhere/releases/tag/14.135.3">14.135.3</a> for better compatibility with M1 Mac hardware.</li>
-        <li>Handle SSH URLs on azure.com in TFVC.</li>
+        <li>Fix issues caused by a TF license agreement not being accepted when using the plugin. Add actions to accept the agreement manually, if auto-detection fails.</li>
       </ul>
       <br />
     ]]>
@@ -213,5 +208,12 @@
                 class="com.microsoft.alm.plugin.idea.tfvc.ui.servertree.CreateVirtualFolderAction" icon="AllIcons.Actions.NewFolder">
             <add-to-group group-id="TfvcTreePopupMenu" anchor="first"/>
         </action>
+
+        <action class="com.microsoft.alm.plugin.idea.tfvc.ui.settings.EULADialog$ShowTfvcCommandLineClientEulaAction"/>
+        <action class="com.microsoft.alm.plugin.idea.tfvc.ui.settings.EULADialog$ShowTfvcSdkEulaAction"/>
+
+        <!-- Internal actions -->
+        <action internal="true" class="com.microsoft.alm.plugin.idea.tfvc.core.TFVCNotifications$ShowSdkEulaNotification"/>
+        <action internal="true" class="com.microsoft.alm.plugin.idea.tfvc.core.TFVCNotifications$ShowCommandLineClientEulaNotification"/>
     </actions>
 </idea-plugin>

--- a/plugin/resources/META-INF/plugin.xml
+++ b/plugin/resources/META-INF/plugin.xml
@@ -6,7 +6,7 @@
 <idea-plugin allow-bundled-update="true">
     <id>com.microsoft.vso.idea</id>
     <name>Azure DevOps</name>
-    <!-- <version>1.162.1</version> NOTE: Version is set automatically on build, update it in gradle.properties -->
+    <!-- <version>1.162.2</version> NOTE: Version is set automatically on build, update it in gradle.properties -->
     <category>VCS Integration</category>
     <vendor url="https://github.com/microsoft/azure-devops-intellij">Microsoft Corporation</vendor>
     <description><![CDATA[

--- a/plugin/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
+++ b/plugin/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
@@ -172,6 +172,11 @@ Actions.Annotate.Status=Opening the annotate view...
 Actions.Annotate.Error.Title=Annotate Error
 Actions.Annotate.Error.Msg=Cannot find annotation details about the selected file
 
+# TFVC EULA
+Tfvc.EulaAcceptanceIsRequired=To use TFVC, you are required to accept the license agreement.
+Tfvc.Eula.Show.Sdk=Show TF SDK Agreement
+Tfvc.Eula.Show.CommandLine=Show TF Client EULA
+
 #TFVC label action
 Actions.Tfvc.Label.Title=Apply Label...
 Actions.Tfvc.Label.Message=Create or update a TFVC label with the selected items.

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/ToolEulaNotAcceptedException.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/ToolEulaNotAcceptedException.java
@@ -7,4 +7,8 @@ public class ToolEulaNotAcceptedException extends RuntimeException {
     public ToolEulaNotAcceptedException(Throwable throwable) {
         super("EULA not accepted", throwable);
     }
+
+    public ToolEulaNotAcceptedException(String message) {
+        super(message);
+    }
 }

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/resources/TfPluginBundle.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/resources/TfPluginBundle.java
@@ -127,6 +127,12 @@ public class TfPluginBundle {
     public static final String KEY_TFVC_REPOSITORY_IMPORT_SUCCESS = "Tfvc.RepositoryImportSuccess";
     @NonNls
     public static final String KEY_TFVC_WORKSPACE_NOT_DETECTED = "Tfvc.WorkspaceNotDetected";
+    @NonNls
+    public static final String KEY_TFVC_EULA_ACCEPTANCE_IS_REQUIRED = "Tfvc.EulaAcceptanceIsRequired";
+    @NonNls
+    public static final String KEY_TFVC_EULA_SHOW_SDK = "Tfvc.Eula.Show.Sdk";
+    @NonNls
+    public static final String KEY_TFVC_EULA_SHOW_COMMAND_LINE = "Tfvc.Eula.Show.CommandLine";
 
     // TFVC Checkout
     @NonNls

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/services/PropertyServiceImpl.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/services/PropertyServiceImpl.java
@@ -9,7 +9,6 @@ import com.microsoft.alm.plugin.idea.common.settings.SettingsChangedNotifier;
 import com.microsoft.alm.plugin.idea.common.settings.TeamServicesSettingsService;
 import com.microsoft.alm.plugin.services.PropertyService;
 
-import java.util.Collections;
 import java.util.Map;
 
 public class PropertyServiceImpl implements PropertyService {
@@ -31,13 +30,13 @@ public class PropertyServiceImpl implements PropertyService {
     }
 
     @Override
-    public String getProperty(final String propertyName) {
+    public synchronized String getProperty(final String propertyName) {
         ensureRestored();
         return map.get(propertyName);
     }
 
     @Override
-    public void setProperty(final String propertyName, final String value) {
+    public synchronized void setProperty(final String propertyName, final String value) {
         ensureRestored();
         if (value == null) {
             removeProperty(propertyName);
@@ -55,16 +54,16 @@ public class PropertyServiceImpl implements PropertyService {
     }
 
     @Override
-    public void removeProperty(final String propertyName) {
+    public synchronized void removeProperty(final String propertyName) {
         map.remove(propertyName);
     }
 
-    public Map<String, String> getProperties() {
+    public synchronized Map<String, String> getProperties() {
         if (map == null) {
             return null;
         }
 
-        return Collections.unmodifiableMap(map);
+        return Map.copyOf(map);
     }
 
     private void ensureRestored() {

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListener.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSFileSystemListener.java
@@ -26,6 +26,7 @@ import com.microsoft.alm.plugin.idea.tfvc.core.tfs.StatusProvider;
 import com.microsoft.alm.plugin.idea.tfvc.core.tfs.StatusVisitor;
 import com.microsoft.alm.plugin.idea.tfvc.core.tfs.TFVCUtil;
 import com.microsoft.alm.plugin.idea.tfvc.core.tfs.TfsFileUtil;
+import com.microsoft.alm.plugin.idea.tfvc.ui.settings.EULADialog;
 import com.microsoft.tfs.model.connector.TfsLocalPath;
 import com.microsoft.tfs.model.connector.TfsPath;
 import com.microsoft.tfs.model.connector.TfsServerPath;
@@ -101,7 +102,11 @@ public class TFSFileSystemListener implements LocalFileOperationsHandler, Dispos
         }
 
         TfvcClient tfvcClient = TfvcClient.getInstance();
-        ServerContext serverContext = vcs.getServerContext(true);
+        ServerContext serverContext = EULADialog.executeWithGuard(myProject, () -> vcs.getServerContext(true));
+        if (serverContext == null){
+            ourLogger.warn("EULA not accepted");
+            return false;
+        }
 
         List<PendingChange> pendingChanges = tfvcClient.getStatusForFiles(
                 currentProject,

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFVCNotifications.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFVCNotifications.java
@@ -8,6 +8,8 @@ import com.intellij.notification.NotificationDisplayType;
 import com.intellij.notification.NotificationGroup;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
@@ -16,6 +18,7 @@ import com.intellij.util.ui.update.MergingUpdateQueue;
 import com.intellij.util.ui.update.Update;
 import com.microsoft.alm.plugin.idea.common.resources.TfPluginBundle;
 import com.microsoft.alm.plugin.idea.tfvc.actions.AddFileToTfIgnoreAction;
+import com.microsoft.alm.plugin.idea.tfvc.ui.settings.EULADialog;
 import org.jetbrains.annotations.NotNull;
 
 public class TFVCNotifications {
@@ -48,5 +51,40 @@ public class TFVCNotifications {
             }
         });
         UIUtil.invokeLaterIfNeeded(ourQueue::activate);
+    }
+
+    public static Notification createSdkEulaNotification() {
+        return TFS_NOTIFICATIONS.createNotification(
+                TfPluginBundle.message(TfPluginBundle.KEY_TFVC_EULA_ACCEPTANCE_IS_REQUIRED),
+                NotificationType.WARNING
+        ).addAction(new EULADialog.ShowTfvcSdkEulaAction());
+    }
+
+    public static Notification createCommandLineClientEulaNotification() {
+        return TFS_NOTIFICATIONS.createNotification(
+                TfPluginBundle.message(TfPluginBundle.KEY_TFVC_EULA_ACCEPTANCE_IS_REQUIRED),
+                NotificationType.WARNING
+        ).addAction(new EULADialog.ShowTfvcCommandLineClientEulaAction());
+    }
+
+    public static class ShowSdkEulaNotification extends AnAction {
+        public ShowSdkEulaNotification() {
+            super("[Internal] Show SDK License Agreement Notification");
+        }
+
+        @Override
+        public void actionPerformed(@NotNull AnActionEvent e) {
+            createSdkEulaNotification().notify(e.getProject());
+        }
+    }
+
+    public static class ShowCommandLineClientEulaNotification extends AnAction {
+        public ShowCommandLineClientEulaNotification() {
+            super("[Internal] Show TF CLC EULA Notification");
+        }
+        @Override
+        public void actionPerformed(@NotNull AnActionEvent e) {
+            createCommandLineClientEulaNotification().notify(e.getProject());
+        }
     }
 }


### PR DESCRIPTION
1. In certain cases, when showing a EULA dialog is impossible (the current thread holds a read or a write lock), we'll show a corresponding notification.
   An exception may still be thrown in those cases, but this shouldn't matter: after accepting the EULA, everything should start working correctly. Or, in the worst case, after accepting EULA and restarting the IDE.
2. There are new internal actions (`-Didea.is.internal=true`) to show the notifications (for QA purposes).
3. For cases when something's completely wrong and the user still cannot accept the EULA or see the notification, there are new _non-internal_ actions: **Show TF Client EULA**, **Show TF SDK Agreement**.
   The users will be able to invoke them manually if required.
4. `PropertyServiceImpl` is now more thread-safe.