### PR TITLE
Fix exceptions thrown when a client license is not accepted

### DIFF
--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFVCNotifications.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFVCNotifications.java
@@ -20,6 +20,7 @@ import com.microsoft.alm.plugin.idea.common.resources.TfPluginBundle;
 import com.microsoft.alm.plugin.idea.tfvc.actions.AddFileToTfIgnoreAction;
 import com.microsoft.alm.plugin.idea.tfvc.ui.settings.EULADialog;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class TFVCNotifications {
     private static final NotificationGroup TFS_NOTIFICATIONS = new NotificationGroup(
@@ -51,6 +52,19 @@ public class TFVCNotifications {
             }
         });
         UIUtil.invokeLaterIfNeeded(ourQueue::activate);
+    }
+
+    public static void notify(
+            @NotNull Notification notification,
+            @Nullable Project project,
+            @NotNull Object deduplicationKey) {
+        ourQueue.queue(new Update(deduplicationKey) {
+            @Override
+            public void run() {
+                notification.notify(project);
+            }
+        });
+        ourQueue.activate();
     }
 
     public static Notification createSdkEulaNotification() {

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/extensions/TfvcRootChecker.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/extensions/TfvcRootChecker.java
@@ -63,7 +63,7 @@ public class TfvcRootChecker extends VcsRootChecker {
         }
 
         // Will get here only if cachedStatus == UNKNOWN.
-        return EULADialog.executeWithGuard(null, () -> {
+        return Boolean.TRUE.equals(EULADialog.executeWithGuard(null, () -> {
             TfsDetailedWorkspaceInfo workspace = null;
             Path workspacePath = Paths.get(path);
             try {
@@ -81,7 +81,7 @@ public class TfvcRootChecker extends VcsRootChecker {
             myCache.putMappings(workspace.getMappings());
             return workspace.getMappings().stream()
                     .anyMatch(mapping -> FileUtil.pathsEqual(path, mapping.getLocalPath().getPath()));
-        });
+        }));
     }
 
     @Override

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/ui/settings/EULADialog.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/ui/settings/EULADialog.java
@@ -306,7 +306,7 @@ public class EULADialog extends DialogWrapper {
         var notification = service.useReactiveClient()
                 ? TFVCNotifications.createSdkEulaNotification()
                 : TFVCNotifications.createCommandLineClientEulaNotification();
-        notification.notify(project);
+        TFVCNotifications.notify(notification, project, service.useReactiveClient() ? "SdkLicense" : "ClassicLicense");
     }
 
     public static class ShowTfvcSdkEulaAction extends AnAction implements DumbAware {


### PR DESCRIPTION
- Fixes [an exception reported to JetBrains](https://youtrack.jetbrains.com/issue/RIDER-86514).
- Adds throttling to license notifications to not show several notifications about the same issue at once.