### PR TITLE
License-related fixes + UI-related code cleanup

### DIFF
--- a/plugin/resources/META-INF/plugin.xml
+++ b/plugin/resources/META-INF/plugin.xml
@@ -59,7 +59,7 @@
     <change-notes><![CDATA[
       <br />
       <ul>
-        <li>Fix issues caused by a TF license agreement not being accepted when using the plugin. Add actions to accept the agreement manually, if auto-detection fails.</li>
+        <li>Fix issues caused by a TF license agreement not being accepted when using the plugin. Add actions to accept the agreement manually, for cases when auto-detection fails.</li>
       </ul>
       <br />
     ]]>

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
@@ -17,6 +17,7 @@ import com.microsoft.alm.plugin.external.exceptions.ToolParseFailureException;
 import com.microsoft.alm.plugin.external.models.Workspace;
 import com.microsoft.alm.plugin.external.tools.TfTool;
 import com.microsoft.alm.plugin.external.utils.WorkspaceHelper;
+import com.microsoft.alm.plugin.idea.tfvc.ui.settings.LicenseKind;
 import com.microsoft.tfs.model.connector.TfsLocalPath;
 import com.microsoft.tfs.model.connector.TfsServerPath;
 import com.microsoft.tfs.model.connector.TfsWorkspaceMapping;
@@ -241,7 +242,7 @@ public abstract class Command<T> {
             Throwable error = syncError.get();
             if (error != null) {
                 if (error.getMessage().contains("tf eula")) {
-                    throw new ToolEulaNotAcceptedException(error);
+                    throw new ToolEulaNotAcceptedException(LicenseKind.CommandLineClient, error);
                 }
                 if (error instanceof RuntimeException) {
                     logger.warn("Error: {}\nSync stack trace: {}", error, StringUtils.join(Thread.currentThread().getStackTrace(), "\n    at "));

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/ToolEulaNotAcceptedException.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/ToolEulaNotAcceptedException.java
@@ -3,12 +3,27 @@
 
 package com.microsoft.alm.plugin.external.commands;
 
+import com.microsoft.alm.plugin.idea.tfvc.ui.settings.LicenseKind;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 public class ToolEulaNotAcceptedException extends RuntimeException {
-    public ToolEulaNotAcceptedException(Throwable throwable) {
-        super("EULA not accepted", throwable);
+
+    private final @NotNull LicenseKind myLicenseKind;
+    public @NotNull LicenseKind getLicenseKind() {
+        return myLicenseKind;
     }
 
-    public ToolEulaNotAcceptedException(String message) {
-        super(message);
+    public ToolEulaNotAcceptedException(@NotNull LicenseKind licenseKind, @NotNull Throwable throwable) {
+        this(licenseKind, null, throwable);
+    }
+
+    public ToolEulaNotAcceptedException(@NotNull LicenseKind licenseKind, @NotNull String message) {
+        this(licenseKind, message, null);
+    }
+
+    private ToolEulaNotAcceptedException(@NotNull LicenseKind kind, @Nullable String message, @Nullable Throwable cause) {
+        super(message == null ? "EULA not accepted" : message, cause);
+        myLicenseKind = kind;
     }
 }

--- a/plugin/src/com/microsoft/alm/plugin/external/reactive/ReactiveTfvcClientHolder.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/reactive/ReactiveTfvcClientHolder.java
@@ -15,6 +15,7 @@ import com.microsoft.alm.plugin.external.commands.ToolEulaNotAcceptedException;
 import com.microsoft.alm.plugin.idea.common.settings.SettingsChangedNotifier;
 import com.microsoft.alm.plugin.idea.common.utils.IdeaHelper;
 import com.microsoft.alm.plugin.idea.tfvc.ui.settings.EULADialog;
+import com.microsoft.alm.plugin.idea.tfvc.ui.settings.LicenseKind;
 import com.microsoft.alm.plugin.services.PropertyService;
 import org.jetbrains.annotations.Nullable;
 
@@ -78,12 +79,16 @@ public class ReactiveTfvcClientHolder implements Disposable {
         String eulaAccepted = propertyService.getProperty(PropertyService.PROP_TF_SDK_EULA_ACCEPTED);
         if (!"true".equalsIgnoreCase(eulaAccepted)) {
             if (!EULADialog.isEulaDialogAllowed()) {
-                throw new ToolEulaNotAcceptedException("EULA acceptance is required to use the reactive TF client");
+                throw new ToolEulaNotAcceptedException(
+                        LicenseKind.TfsSdk,
+                        "EULA acceptance is required to use the reactive TF client");
             }
 
             ApplicationManager.getApplication().invokeAndWait(() -> {
                 if (!EULADialog.forTfsSdk(project).showAndGet())
-                    throw new ToolEulaNotAcceptedException("EULA acceptance is required to use the reactive TF client");
+                    throw new ToolEulaNotAcceptedException(
+                            LicenseKind.TfsSdk,
+                            "EULA acceptance is required to use the reactive TF client");
             }, ModalityState.any()); // EULA should be shown even if there's a modal dialog (e.g. a commit one)
         }
     }

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/ui/controls/Hyperlink.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/ui/controls/Hyperlink.java
@@ -3,15 +3,11 @@
 
 package com.microsoft.alm.plugin.idea.common.ui.controls;
 
-import com.intellij.ui.JBColor;
 import com.intellij.ui.components.labels.LinkLabel;
 import com.intellij.ui.components.labels.LinkListener;
-import com.microsoft.alm.plugin.idea.common.utils.BackCompatibleUtils;
 
-import java.awt.Graphics;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.FocusEvent;
 import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 import java.util.List;
@@ -57,27 +53,6 @@ public class Hyperlink extends LinkLabel<Object> {
         if (e.getKeyCode() == KeyEvent.VK_SPACE || e.getKeyCode() == KeyEvent.VK_ENTER) {
             e.consume();
             notifyActionListeners();
-        }
-    }
-
-    /**
-     * We are overriding this method to force a repaint of the control when the focus changes.
-     */
-    @Override
-    protected void processFocusEvent(final FocusEvent e) {
-        super.processFocusEvent(e);
-        super.repaint();
-    }
-
-    /**
-     * We are overriding this method to paint a focus rectangle around the control.
-     */
-    @Override
-    protected void paintComponent(final Graphics g) {
-        super.paintComponent(g);
-        if (hasFocus()) {
-            g.setColor(JBColor.black);
-            BackCompatibleUtils.paintFocusRing(g, 0, 0, getWidth(), getHeight());
         }
     }
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/utils/BackCompatibleUtils.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/utils/BackCompatibleUtils.java
@@ -3,14 +3,11 @@
 
 package com.microsoft.alm.plugin.idea.common.utils;
 
-import com.intellij.ide.ui.laf.darcula.DarculaUIUtil;
 import com.intellij.util.net.HttpConfigurable;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.awt.Graphics;
-import java.awt.Rectangle;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
@@ -42,32 +39,6 @@ public class BackCompatibleUtils {
             } catch (Exception oldImplementationException) {
                 logger.warn("Failed to get proxy login using PROXY_LOGIN field", oldImplementationException);
                 return StringUtils.EMPTY;
-            }
-        }
-    }
-
-    /**
-     * Executing the DarculaUIUtil.paintFocusRing() method independent of the IDEA version we are on
-     *
-     * @param g
-     * @param x
-     * @param y
-     * @param width
-     * @param height
-     */
-    public static void paintFocusRing(final Graphics g, final int x, final int y, final int width, final int height) {
-        try {
-            // trying to paint focus using the IDEA 2017 method
-            final Method paintFocusRingMethodNew = DarculaUIUtil.class.getDeclaredMethod("paintFocusRing", Graphics.class, Rectangle.class);
-            paintFocusRingMethodNew.invoke(null, g, new Rectangle(x, y, width, height));
-        } catch (Exception newImplementationException) {
-            try {
-                logger.warn("Failed to get DarculaUIUtil.paintFocusRing() new implementation so attempting old way", newImplementationException);
-                final Method paintFocusRingMethodOld = DarculaUIUtil.class.getDeclaredMethod("paintFocusRing", Graphics.class,
-                        Integer.TYPE, Integer.TYPE, Integer.TYPE, Integer.TYPE);
-                paintFocusRingMethodOld.invoke(null, g, x, y, width, height);
-            } catch (Exception oldImplementationException) {
-                logger.warn("Failed to find DarculaUIUtil.paintFocusRing() method", oldImplementationException);
             }
         }
     }

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFVCNotifications.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFVCNotifications.java
@@ -11,6 +11,7 @@ import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
 import com.intellij.util.ui.UIUtil;
@@ -29,7 +30,7 @@ public class TFVCNotifications {
             true
     );
 
-    private static MergingUpdateQueue ourQueue = new MergingUpdateQueue(
+    private static final MergingUpdateQueue ourQueue = new MergingUpdateQueue(
             "TFVCNotifications.myQueue",
             2000,
             false,
@@ -64,7 +65,7 @@ public class TFVCNotifications {
                 notification.notify(project);
             }
         });
-        ourQueue.activate();
+        ApplicationManager.getApplication().invokeLater(ourQueue::activate, ModalityState.NON_MODAL);
     }
 
     public static Notification createSdkEulaNotification() {

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/ui/settings/LicenseKind.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/ui/settings/LicenseKind.java
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.alm.plugin.idea.tfvc.ui.settings;
+
+public enum LicenseKind {
+    CommandLineClient,
+    TfsSdk
+}


### PR DESCRIPTION
This PR adds some fixes for advanced scenarios related to #539.

Also, I've cleaned up some old reflection-based code for theming that was writing a lot of warnings. It turns out that the related issue is already fixed in the modern IDEs, and hyperlink has the focus border anyway.