### PR TITLE
Refactor move "Open in browser" action to "Open In" menu

### DIFF
--- a/plugin/resources/META-INF/plugin.xml
+++ b/plugin/resources/META-INF/plugin.xml
@@ -136,7 +136,7 @@
 
     <actions>
         <action id="VSO.Open.In.Browser" class="com.microsoft.alm.plugin.idea.common.actions.OpenFileInBrowserAction">
-            <add-to-group group-id="EditorPopupMenu"/>
+            <add-to-group group-id="RevealGroup"/>
             <add-to-group group-id="ProjectViewPopupMenu"/>
             <add-to-group group-id="EditorTabPopupMenu"/>
         </action>

--- a/plugin/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
+++ b/plugin/resources/com/microsoft/alm/plugin/idea/ui/tfplugin.properties
@@ -159,7 +159,7 @@ Feedback.Dialog.Errors.InvalidEmail=The email address ''{0}'' is not valid. Ente
 Feedback.Notification=Thank you\! Your feedback has been sent.
 
 #actions
-Actions.OpenInBrowser.Title=Open in Browser
+Actions.OpenInBrowser.Title=Browser
 Actions.OpenInBrowser.Message=Open the corresponding link in an external browser
 Actions.Import.Title=Import into Azure DevOps Services Git...
 Actions.Import.Message=Import the current project into a remote Git repository in Azure DevOps Services


### PR DESCRIPTION
The Azure plugin provides "Open in Browser" as its own action within the Editor pop-up menu.

A better place for this action is the "Open In" as sub action, similar to what Github does.
![Screenshot 2024-01-16 at 14 06 56 2](https://github.com/microsoft/azure-devops-intellij/assets/14923445/3d63b3d1-3cf3-464d-8b1f-5b277c816436)

P.S. Maybe it is OCD, or being neurotic 😅 is the actual reason behind this PR.

# 🎨 

## Before PR
![Screenshot 2024-01-16 at 14 09 04](https://github.com/microsoft/azure-devops-intellij/assets/14923445/1b188243-c31f-46d7-873b-586d24129e51)

## After PR
![Screenshot 2024-01-16 at 11 34 38 2](https://github.com/microsoft/azure-devops-intellij/assets/14923445/afbdcbb0-1585-49a6-85cc-ffed97186e89)